### PR TITLE
bugfix: if crash was started while crate was still starting crash

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for crash
 Unreleased
 ==========
 
+ - bugfix: if crash was started while one of the specified hosts was
+   not available crash exited immediately
+
 2014/05/09 0.9.2
 ================
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ import re
 
 requirements = [
     'setuptools',
-    'crate>=0.9.3',
+    'crate>=0.9.4',
     'PrettyTable>=0.7,<0.8',
     'appdirs>=1.2,<2.0',
 ]

--- a/versions.cfg
+++ b/versions.cfg
@@ -6,7 +6,7 @@ setuptools = 1.1
 lovely.testlayers = 0.6.0
 
 crate_server = 0.33.0
-crate = 0.9.3
+crate = 0.9.4
 
 # Required by:
 # crate==0.9.0


### PR DESCRIPTION
exited immediately
