### PR TITLE
bugfix: crash exited immediately with an exception if a query result

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for crash
 Unreleased
 ==========
 
+ - bugfix: crash exited immediately with an exception if a query result
+   contained an object or array
+
  - the size of the history file is now limited to 10000 lines
 
  - stdin is no longer read completely into memory

--- a/src/crate/crash/tabulate.py
+++ b/src/crate/crash/tabulate.py
@@ -236,7 +236,7 @@ def _isconvertible(conv, string):
     try:
         n = conv(string)
         return True
-    except ValueError:
+    except (ValueError, TypeError):
         return False
 
 

--- a/src/crate/crash/test_command.py
+++ b/src/crate/crash/test_command.py
@@ -78,3 +78,29 @@ class CommandTest(TestCase):
             except IOError:
                 pass
             sys.argv = orig_argv
+
+    def test_rendering_object(self):
+        """Test rendering an object"""
+        name = {'name': 'Arthur'}
+        expected = "\n".join(["+--------------------+",
+                              "| name               |",
+                              "+--------------------+",
+                              "| {'name': 'Arthur'} |",
+                              "+--------------------+\n"])
+        command = CrateCmd()
+        with patch('sys.stdout', new_callable=StringIO) as output:
+            command.pprint([[name]], ['name'])
+            self.assertEqual(expected, output.getvalue())
+
+    def test_rendering_array(self):
+        """Test rendering an array"""
+        names = ['Arthur', 'Ford']
+        expected = "\n".join(["+--------------------+",
+                              "| names              |",
+                              "+--------------------+",
+                              "| ['Arthur', 'Ford'] |",
+                              "+--------------------+\n"])
+        command = CrateCmd()
+        with patch('sys.stdout', new_callable=StringIO) as output:
+            command.pprint([[names]], ['names'])
+            self.assertEqual(expected, output.getvalue())


### PR DESCRIPTION
contained an object or array
