### PR TITLE
set stdin_data to None on non-posix systems

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for crash
 Unreleased
 ==========
 
+ - Fixed an error that caused crash to crash on non posix platforms.
+
 2014/10/02 0.10.2
 =================
 

--- a/src/crate/crash/command.py
+++ b/src/crate/crash/command.py
@@ -493,6 +493,8 @@ def main():
     done = False
     if os.name == 'posix':
         stdin_data = get_stdin()
+    else:
+        stdin_data = None
     if args.command:
         for single_cmd in args.command.split(CrateCmd.line_delimiter):
             cmd.onecmd(single_cmd)


### PR DESCRIPTION
otherwise the elif stdin_data check further down will fail. With this crash
works correctly on windows.
