### PR TITLE
don't specify argparse in versions.cfg

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -6,7 +6,6 @@ MarkupSafe = 0.23
 Pygments = 1.6
 Sphinx = 1.2.3
 appdirs = 1.4.0
-argparse = 1.2.1
 collective.recipe.omelette = 0.16
 crate = 0.12.3
 crate-docs-theme = 0.3.6


### PR DESCRIPTION
python3 includes argparse by default which is usually argparse 1.1, so
requiring a newer version won't work
