### PR TITLE
Update copyright year in license: Trello #693

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 CRATE Python Adapter
-Copyright 2013-2014 CRATE Technology GmbH ("Crate")
+Copyright 2013-2015 CRATE Technology GmbH ("Crate")
 
 
 Licensed to CRATE Technology GmbH (referred to in this notice as "Crate")


### PR DESCRIPTION
The year in the license file needed to be updated from 2014 to 2015