### PR TITLE
fix py3 exception logging error

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for crash
 Unreleased
 ==========
 
+ - Fixed an error that occurred under python 3 if one of the built-in commands
+   that require an argument were called without argument.
+
 2015/12/14 0.15.0
 =================
 

--- a/src/crate/crash/command.py
+++ b/src/crate/crash/command.py
@@ -272,13 +272,13 @@ class CrateCmd(object):
             try:
                 message = cmd(*words[1:])
             except TypeError as e:
-                self.logger.critical(e.message)
+                self.logger.critical(getattr(e, 'message', None) or repr(e))
                 doc = cmd.__doc__
                 if doc and not doc.isspace():
                     self.logger.info('help: {0}'.format(words[0].lower()))
                     self.logger.info(cmd.__doc__)
             except Exception as e:
-                self.logger.critical(e.message)
+                self.logger.critical(getattr(e, 'message', None) or repr(e))
             else:
                 if message:
                     self.logger.info(message)


### PR DESCRIPTION
In python3 TypeError doesn't have a message attribute.