### PR TITLE
json output: order keys by the select list

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for crash
 Unreleased
 ==========
 
+ - The order of the keys / columns of the ``json`` output format is now
+   deterministic and reflects the order of the columns in the executed query.
+
  - `Ctrl-c` no longer results in a KeyboardInterrupt exception if invoked while
    a query is being executed.
 


### PR DESCRIPTION
E.g.

    select x, y

Results in

    {
        "x",
        "y"
    }

And

    select y, x

results in

    {
        "y",
        "x"
    }

Instead of having a random order