### PR TITLE
move KeyboardInterrupt handling into repl

### DIFF
--- a/src/crate/crash/command.py
+++ b/src/crate/crash/command.py
@@ -283,8 +283,6 @@ class CrateCmd(object):
             return True
         except ConnectionError:
             self.logger.warn('Use \connect <server> to connect to one or more servers first.')
-        except KeyboardInterrupt:
-            self.logger.warn("Query not cancelled. Run KILL <jobId> to cancel it")
         except ProgrammingError as e:
             self.logger.critical(e.message)
             if self.error_trace:

--- a/src/crate/crash/repl.py
+++ b/src/crate/crash/repl.py
@@ -180,6 +180,8 @@ def loop(cmd, history_file):
             doc = cli.run()
             if doc:
                 cmd.process(doc.text)
+        except KeyboardInterrupt:
+            cmd.logger.warn("Query not cancelled. Run KILL <jobId> to cancel it")
         except EOFError:
             cmd.logger.warn(u'Bye!')
             return


### PR DESCRIPTION
Catching KeyboardInterrupt in the CrateCmd makes it impossible to
interrupt processes that use the CrateCmd class (Like the doctests in
Crate do)

This commit moves the KeyboardInterrupt handling into the repl module so
that it will only be caught if crash is used interactively. (That was
the original intention when it was added.)