### PR TITLE
Enable/disable autocomplete

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,8 +5,12 @@ Changes for crash
 Unreleased
 ==========
 
+ - It is now possible to disable autocompletion using ``--no-autocomplete``
+   command line argument and to toggle autocomplete using the ``\autocomplete``
+   crash command.
+
  - Fixed result info command output for whitespace other than space
-   characters in queries. 
+   characters in queries.
 
  - Fixed call of `sysinfo` command when launching the shell.
 

--- a/docs/cli.txt
+++ b/docs/cli.txt
@@ -50,11 +50,11 @@ Crash Commands
 
 .. note::
 
-    Crash client commands are only available since version ``0.11.x``!
+    Crash client commands are available since version ``0.11.x``!
 
-Crash has several client command, which start with a backslash (``\``).
+Crash has several client commands, which start with a backslash (``\``).
 
-You can get a list of commands by typing the command ``\?``:
+You can get a list of commands by typing ``\?``:
 
 +----------------------+------------------------------------------------------------------------------------+
 | Command              | Description                                                                        |
@@ -78,7 +78,7 @@ You can get a list of commands by typing the command ``\?``:
 +----------------------+------------------------------------------------------------------------------------+
 | ``\check``           | Query the sys.checks table for failing cluster checks                              |
 +----------------------+------------------------------------------------------------------------------------+
-| ``\r <filename>``    | Reads statements from the given file and execute them                              |
+| ``\r <filename>``    | Reads statements from the given file and executes them                              |
 +----------------------+------------------------------------------------------------------------------------+
 | ``\sysinfo``         | Query the ``sys`` tables for system and cluster information                        |
 +----------------------+------------------------------------------------------------------------------------+

--- a/docs/cli.txt
+++ b/docs/cli.txt
@@ -25,6 +25,12 @@ The ``crash`` binary supports several command line arguments.
 +---------------------------------------+--------------------------------------------------+
 | ``--sysinfo``                         | Print system and cluster information.            |
 +---------------------------------------+--------------------------------------------------+
+| ``-A`` , ``--no-autocomplete``        | Disable autocomplete of SQL keywords on startup. |
+|                                       | Autocomplete requires a minimum terminal         |
+|                                       | height of 8 lines due to size of the dropdown    |
+|                                       | overlay for suggestions.                         |
+|                                       | Disabling autocomplete removes this limitation.  |
++---------------------------------------+--------------------------------------------------+
 
 Example Usage
 =============
@@ -75,6 +81,8 @@ You can get a list of commands by typing the command ``\?``:
 | ``\r <filename>``    | Reads statements from the given file and execute them                              |
 +----------------------+------------------------------------------------------------------------------------+
 | ``\sysinfo``         | Query the ``sys`` tables for system and cluster information                        |
++----------------------+------------------------------------------------------------------------------------+
+| ``\autocomplete``    | Turn autocomplete feature on or off. Works as a toggle.                            |
 +----------------------+------------------------------------------------------------------------------------+
 
 ===============

--- a/src/crate/crash/command.py
+++ b/src/crate/crash/command.py
@@ -75,6 +75,9 @@ def parse_args(output_formats):
     parser.add_argument('-v', '--verbose', action='count',
                         dest='verbose', default=0,
                         help='use -v to get debug output')
+    parser.add_argument('-A', '--no-autocomplete', action='store_false',
+                        dest='autocomplete', default=True,
+                        help='use -A to disable SQL autocompletion')
     parser.add_argument('--history',
                         type=str,
                         help='the history file to use', default=HISTORY_PATH)
@@ -137,9 +140,13 @@ class CrateCmd(object):
         }
         self.commands.update(built_in_commands)
         self.logger = ColorPrinter(is_tty)
+        self._autocomplete = True
 
     def get_num_columns(self):
         return 80
+
+    def should_autocomplete(self):
+        return self._autocomplete
 
     def pprint(self, rows, cols):
         result = Result(cols,
@@ -360,7 +367,7 @@ def main():
             done = True
     if not done:
         from .repl import loop
-        loop(cmd, args.history)
+        loop(cmd, args.history, args.autocomplete)
     cmd.exit()
     sys.exit(cmd.exit_code)
 

--- a/src/crate/crash/commands.py
+++ b/src/crate/crash/commands.py
@@ -53,6 +53,7 @@ class HelpCommand(Command):
 
 class ReadFileCommand(Command):
     """ read and execute statements from a file """
+
     def complete(self, cmd, text):
         if text.endswith('.sql'):
             return []
@@ -78,8 +79,20 @@ class SwitchFormatCommand(Command):
             fmt, ', '.join(cmd.output_writer.formats))
 
 
+class ToggleAutocompleteCommand(Command):
+    """ toggle autocomplete """
+
+    @noargs_command
+    def __call__(self, cmd, *args, **kwargs):
+        cmd._autocomplete = not cmd._autocomplete
+        return 'Autocomplete {0}'.format(
+            cmd._autocomplete and 'ON' or 'OFF'
+        )
+
+
 built_in_commands = {
     '?': HelpCommand(),
     'r': ReadFileCommand(),
     'format': SwitchFormatCommand(),
+    'autocomplete': ToggleAutocompleteCommand(),
 }

--- a/src/crate/crash/test_command.py
+++ b/src/crate/crash/test_command.py
@@ -415,6 +415,7 @@ class CommandTest(TestCase):
         command = CrateCmd(is_tty=False)
         expected = "\n".join([
             '\\?                              print this help',
+            '\\autocomplete                   toggle autocomplete',
             '\\c                              connect to the given server, e.g.: \connect localhost:4200',
             '\\check                          print failed cluster checks',
             '\\connect                        connect to the given server, e.g.: \connect localhost:4200',

--- a/src/crate/crash/test_commands.py
+++ b/src/crate/crash/test_commands.py
@@ -19,7 +19,7 @@
 
 from unittest import TestCase
 from mock import patch
-from .commands import ReadFileCommand
+from .commands import ReadFileCommand, ToggleAutocompleteCommand
 
 
 class ReadFileCommandTest(TestCase):
@@ -33,3 +33,17 @@ class ReadFileCommandTest(TestCase):
 
         self.assertEqual(results, ['foo', 'foobar'])
         fake_glob.assert_called_with('fo*.sql')
+
+
+class ToggleAutocompleteCommandTest(TestCase):
+
+    @patch('crate.crash.command.CrateCmd')
+    def test_toggle_output(self, fake_cmd):
+        fake_cmd._autocomplete = True
+        command = ToggleAutocompleteCommand()
+        output = command(fake_cmd)
+        self.assertEqual(output, 'Autocomplete OFF')
+        output = command(fake_cmd)
+        self.assertEqual(output, 'Autocomplete ON')
+
+

--- a/src/crate/crash/tests.py
+++ b/src/crate/crash/tests.py
@@ -29,7 +29,7 @@ from crate.testing.layer import CrateLayer
 from .command import CrateCmd
 from .printer import ColorPrinter, PrintWrapper
 from .test_command import CommandTest, OutputWriterTest
-from .test_commands import ReadFileCommandTest
+from .test_commands import ReadFileCommandTest, ToggleAutocompleteCommandTest
 from .test_sysinfo import SysInfoTest
 from .test_repl import SQLCompleterTest
 
@@ -94,6 +94,7 @@ def test_suite():
     suite.addTest(unittest.makeSuite(OutputWriterTest))
     suite.addTest(unittest.makeSuite(SysInfoTest))
     suite.addTest(unittest.makeSuite(ReadFileCommandTest))
+    suite.addTest(unittest.makeSuite(ToggleAutocompleteCommandTest))
     suite.addTest(unittest.makeSuite(SQLCompleterTest))
 
     return suite


### PR DESCRIPTION
It is now possible to disable autocompletion using ``--no-autocomplete`` command line argument and to toggle autocomplete using the ``\autocomplete`` crash command.