### PR TITLE
Update prompt-toolkit to 1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ requirements = [
     'Pygments',
     'crate>=0.11.2',
     'appdirs>=1.2,<2.0',
-    'prompt-toolkit==0.59'
+    'prompt-toolkit>=1.0,<1.1'
 ]
 
 if (2, 6) == sys.version_info[:2]:

--- a/src/crate/crash/command.py
+++ b/src/crate/crash/command.py
@@ -121,7 +121,8 @@ class CrateCmd(object):
                  output_writer=None,
                  connection=None,
                  error_trace=False,
-                 is_tty=True):
+                 is_tty=True,
+                 autocomplete=True):
         self.error_trace = error_trace
         self.connection = connection or connect(error_trace=error_trace)
         self.cursor = self.connection.cursor()
@@ -140,7 +141,7 @@ class CrateCmd(object):
         }
         self.commands.update(built_in_commands)
         self.logger = ColorPrinter(is_tty)
-        self._autocomplete = True
+        self._autocomplete = autocomplete
 
     def get_num_columns(self):
         return 80
@@ -348,7 +349,8 @@ def main():
     cmd = CrateCmd(connection=conn,
                    error_trace=error_trace,
                    output_writer=output_writer,
-                   is_tty=is_tty)
+                   is_tty=is_tty,
+                   autocomplete=args.autocomplete)
     if error_trace:
         # log CONNECT command only in verbose mode
         cmd._connect(args.hosts)
@@ -367,7 +369,7 @@ def main():
             done = True
     if not done:
         from .repl import loop
-        loop(cmd, args.history, args.autocomplete)
+        loop(cmd, args.history)
     cmd.exit()
     sys.exit(cmd.exit_code)
 


### PR DESCRIPTION
Includes a lot of of VI mode improvements!

And the following change makes our `get_height` override unnecessary:

 - Only reserve menu space when `complete_while_typing=True` or when
   there are completions to be displayed.