### PR TITLE
allow short hosts

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for crash
 Unreleased
 ==========
 
+ - Allow "short hosts" as Crate hosts argument,
+   such as ``:4200`` for ``localhost:4200``
+
 2016/10/12 0.18.1
 =================
 

--- a/src/crate/crash/command.py
+++ b/src/crate/crash/command.py
@@ -359,6 +359,23 @@ def get_stdin():
     return
 
 
+def host_and_port(host_or_port):
+    """
+    Return full hostname/IP + port, possible input formats are:
+      * host:port  -> host:port
+      * :          -> localhost:4200
+      * :port      -> localhost:port
+      * host       -> host:4200
+    """
+    if ':' in host_or_port:
+        if len(host_or_port) == 1:
+            return 'localhost:4200'
+        elif host_or_port.startswith(':'):
+            return 'localhost' + host_or_port
+        return host_or_port
+    return host_or_port + ':4200'
+
+
 def main():
     is_tty = sys.stdout.isatty()
     printer = ColorPrinter(is_tty)
@@ -381,7 +398,8 @@ def main():
         printer.info(crash_version)
         sys.exit(0)
     error_trace = args.verbose > 0
-    conn = connect(args.hosts,
+    crate_hosts = [host_and_port(h) for h in args.hosts]
+    conn = connect(crate_hosts,
                    verify_ssl_cert=args.verify_ssl,
                    cert_file=args.cert_file,
                    key_file=args.key_file)
@@ -392,7 +410,7 @@ def main():
                    autocomplete=args.autocomplete)
     if error_trace:
         # log CONNECT command only in verbose mode
-        cmd._connect(args.hosts)
+        cmd._connect(crate_hosts)
     done = False
     stdin_data = get_stdin()
     if args.sysinfo:

--- a/src/crate/crash/test_command.py
+++ b/src/crate/crash/test_command.py
@@ -8,7 +8,7 @@ from io import TextIOWrapper
 from mock import patch, Mock
 from crate.client.exceptions import ProgrammingError
 
-from .command import CrateCmd, main, get_stdin, noargs_command, Result
+from .command import CrateCmd, main, get_stdin, noargs_command, Result, host_and_port
 from .outputs import _val_len as val_len, OutputWriter
 from .printer import ColorPrinter
 from .commands import Command
@@ -56,6 +56,22 @@ class OutputWriterTest(TestCase):
         output = ow.tabular(result).split('\n')[3]
         self.assertEqual(
             output.strip('|').strip(' '), expected)
+
+
+class CommandLineArgumentsTest(TestCase):
+
+    def test_short_hostnames(self):
+        # both host and port are provided
+        self.assertEqual(host_and_port('localhost:4321'), 'localhost:4321')
+        # only host is provided
+        # default port is used
+        self.assertEqual(host_and_port('localhost'), 'localhost:4200')
+        # only port is provided
+        # localhost is used
+        self.assertEqual(host_and_port(':4000'), 'localhost:4000')
+        # neither host nor port are provided
+        # default host and default port are used
+        self.assertEqual(host_and_port(':'), 'localhost:4200')
 
 
 class CommandTest(TestCase):


### PR DESCRIPTION
e.g.

* `:` for <default_host>:<default_port> -> `localhost:4200`
* `:4321` for `<default_host>:4321` -> `localhost:4321`
* `crate1.example.com` for  `crate1.example.com:<default_port>` -> `crate1.example.com:4200`