### PR TITLE
fixed unicode error in --sysinfo command

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for crash
 Unreleased
 ==========
 
+ - ``--sysinfo`` does not fail any more when the name of the connected CrateDB
+   node contains a unicode character.
+
  - Crash was trying to connect to invalid hosts if no hosts were provided via
   ``--hosts`` argument and configuration file was already present.
 

--- a/src/crate/crash/outputs.py
+++ b/src/crate/crash/outputs.py
@@ -116,7 +116,7 @@ class OutputWriter(object):
         padding = max_col_len = max(len(c) for c in result.cols)
         if self.is_tty:
             max_col_len += len(Fore.YELLOW + Style.RESET_ALL)
-        tmpl = '{0:<' + str(max_col_len) + '} | {1}'
+        tmpl = u'{0:<' + str(max_col_len) + '} | {1}'
         row_delimiter = '-' * result.output_width
         for row in result.rows:
             for i, c in enumerate(result.cols):
@@ -172,4 +172,6 @@ class OutputWriter(object):
             value = '\n'.join(lines)
         elif isinstance(value, float):
             value = float_format(value)
-        return '{0}\n'.format(value)
+        elif isinstance(value, int):
+            value = str(value)
+        return value + '\n'

--- a/src/crate/crash/test_command.py
+++ b/src/crate/crash/test_command.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: set fileencodings=utf-8
+
 import sys
 import os
 import re
@@ -26,21 +29,33 @@ def fake_stdin(data):
 
 
 class OutputWriterTest(TestCase):
+
+    def setUp(self):
+        self.ow = OutputWriter(writer=None, is_tty=False)
+
     def test_mixed_format_float_precision(self):
-        expected = 'foo | 152462.70754934277'
-        ow = OutputWriter(writer=None, is_tty=False)
+        expected = u'foo | 152462.70754934277'
         result = Result(cols=['foo'],
                         rows=[[152462.70754934277]],
                         rowcount=1,
                         duration=1,
                         output_width=80)
         self.assertEqual(
-            next(ow.mixed(result)).rstrip(), expected)
+            next(self.ow.mixed(result)).rstrip(), expected)
+
+    def test_mixed_format_utf8(self):
+        expected = u'name | Großvenediger'
+        result = Result(cols=['name'],
+                        rows=[[u'Großvenediger']],
+                        rowcount=1,
+                        duration=1,
+                        output_width=80)
+        self.assertEqual(
+            next(self.ow.mixed(result)).rstrip(), expected)
 
     def test_tabular_format_float_precision(self):
         expected = u'152462.70754934277'
 
-        ow = OutputWriter(writer=None, is_tty=False)
         result = Result(cols=['foo'],
                         rows=[[152462.70754934277]],
                         rowcount=1,
@@ -53,7 +68,7 @@ class OutputWriterTest(TestCase):
         # +----
         # | value
         # get the row with the value in it
-        output = ow.tabular(result).split('\n')[3]
+        output = self.ow.tabular(result).split('\n')[3]
         self.assertEqual(
             output.strip('|').strip(' '), expected)
 
@@ -379,8 +394,7 @@ class CommandTest(TestCase):
         try:
             main()
         except SystemExit as e:
-            exception_code = e.code
-        self.assertEqual(exception_code, 1)
+            self.assertEqual(e.code, 1)
 
     def test_verbose_with_error_trace(self):
         command = CrateCmd(error_trace=True)


### PR DESCRIPTION
happened when node name contains unicode character such as umlaut

Error message was:
```
Traceback (most recent call last):
  File "bin/crash", line 24, in <module>
    sys.exit(crate.crash.command.main())
  File "/Users/christian/sandbox/crate/crash/src/crate/crash/command.py", line 429, in main
    cmd.sys_info_cmd.execute()
  File "/Users/christian/sandbox/crate/crash/src/crate/crash/sysinfo.py", line 93, in execute
    self.cmd.pprint(result.rows, result.cols)
  File "/Users/christian/sandbox/crate/crash/src/crate/crash/command.py", line 217, in pprint
    self.output_writer.write(result)
  File "/Users/christian/sandbox/crate/crash/src/crate/crash/outputs.py", line 94, in write
    for line in output:
  File "/Users/christian/sandbox/crate/crash/src/crate/crash/outputs.py", line 123, in mixed
    val = self._mixed_format(row[i], max_col_len, padding)
  File "/Users/christian/sandbox/crate/crash/src/crate/crash/outputs.py", line 175, in _mixed_format
    return '{0}\n'.format(value)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xdf' in position 3: ordinal not in range(128)
```

@mfussenegger please!