### PR TITLE
\dt command now also works when connecting to a CrateDB version < 0.57.0

### DIFF
--- a/src/crate/crash/command.py
+++ b/src/crate/crash/command.py
@@ -243,12 +243,12 @@ class CrateCmd(object):
     def _show_tables(self, *args):
         """ print the existing tables within the 'doc' schema """
         schema_name = \
-            "table_schema" if self.connection.lowest_server_version\
+            "table_schema" if self.connection.lowest_server_version \
             >= TABLE_SCHEMA_MIN_VERSION else "schema_name"
 
-        self._exec("""select format('%s.%s', {schema}, table_name) as name
-                      from information_schema.tables
-                      where table_schema not in ('sys','information_schema', 'pg_catalog')"""
+        self._exec("select format('%s.%s', {schema}, table_name) as name "
+                   "from information_schema.tables "
+                   "where {schema} not in ('sys','information_schema', 'pg_catalog')"
                    .format(schema=schema_name))
 
     @noargs_command

--- a/src/crate/crash/test_commands.py
+++ b/src/crate/crash/test_commands.py
@@ -25,7 +25,7 @@ import tempfile
 
 from six import StringIO
 from unittest import TestCase
-from mock import patch
+from mock import patch, MagicMock
 from .commands import ReadFileCommand, ToggleAutocompleteCommand, \
     NodeCheckCommand, ClusterCheckCommand, CheckCommand
 
@@ -75,6 +75,22 @@ class ToggleAutocompleteCommandTest(TestCase):
         output = command(fake_cmd)
         self.assertEqual(output, 'Autocomplete ON')
 
+
+class ShowTablesCommandTest(TestCase):
+
+    def test_post_0_57(self):
+        cmd = CrateCmd()
+        cmd._exec = MagicMock()
+        cmd.connection.lowest_server_version = StrictVersion("0.57.0")
+        cmd._show_tables()
+        cmd._exec.assert_called_with("select format('%s.%s', table_schema, table_name) as name from information_schema.tables where table_schema not in ('sys','information_schema', 'pg_catalog')")
+
+    def test_pre_0_57(self):
+        cmd = CrateCmd()
+        cmd._exec = MagicMock()
+        cmd.connection.lowest_server_version = StrictVersion("0.56.4")
+        cmd._show_tables()
+        cmd._exec.assert_called_with("select format('%s.%s', schema_name, table_name) as name from information_schema.tables where schema_name not in ('sys','information_schema', 'pg_catalog')")
 
 class ChecksCommandTest(TestCase):
 

--- a/src/crate/crash/tests.py
+++ b/src/crate/crash/tests.py
@@ -30,7 +30,7 @@ from .command import CrateCmd
 from .printer import ColorPrinter, PrintWrapper
 from .test_command import CommandTest, OutputWriterTest
 from .test_commands import ReadFileCommandTest, ToggleAutocompleteCommandTest, \
-    ChecksCommandTest
+    ChecksCommandTest, ShowTablesCommandTest
 from .test_sysinfo import SysInfoTest
 from .test_repl import SQLCompleterTest
 from .test_config import ConfigurationTest
@@ -98,6 +98,7 @@ def test_suite():
     suite.addTest(unittest.makeSuite(ReadFileCommandTest))
     suite.addTest(unittest.makeSuite(ToggleAutocompleteCommandTest))
     suite.addTest(unittest.makeSuite(ChecksCommandTest))
+    suite.addTest(unittest.makeSuite(ShowTablesCommandTest))
     suite.addTest(unittest.makeSuite(SQLCompleterTest))
     suite.addTest(unittest.makeSuite(ConfigurationTest))
 


### PR DESCRIPTION
this is a fix for https://github.com/crate/crash/commit/c5abb4e8b3f91202afcbab74acfe3fcc1dc8ebf0 which is not yet released and therefore has no changelog entry