### PR TITLE
travis

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+[report]
+omit =
+    */virtualenv/*
+    */.buildout/eggs/*
+    bin/test
+    buildout-cache/eggs/*
+    parts/*
+    eggs/*
+exclude_lines =
+    raise NotImplemented

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ script:
 
 after_success:
     - PATH=$PATH:bin/ bin/codecov  # codecov executes coverage which needs to be in $PATH
+    - pip install coveralls
+    - coveralls
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,20 @@
 language: python
+cache: pip
 python:
     - 2.7
     - 3.3
     - 3.4
     - 3.5
+    - 3.6
     - pypy
-    - pypy3
     - nightly
 
 before_install:
-    - pip uninstall setuptools -y
+    - pip install --upgrade setuptools
 
 install:
-    - python bootstrap.py --setuptools-version=20.2.2
-    - ./bin/buildout install scripts crate test
+    - python bootstrap.py
+    - bin/buildout install scripts crate test
 
 script:
     - bin/coverage run bin/test

--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,8 @@
 |
 
 .. image:: https://travis-ci.org/crate/crash.svg?branch=master
-        :target: https://travis-ci.org/crate/crash
-        :alt: Test
+    :target: https://travis-ci.org/crate/crash
+    :alt: Travis CI
 
 .. image:: https://badge.fury.io/py/crash.png
     :target: http://badge.fury.io/py/crash
@@ -16,11 +16,15 @@
 
 .. image:: https://img.shields.io/badge/docs-latest-brightgreen.svg
     :target: https://crate.io/docs/reference/crash/
+    :alt: Documentation
 
 .. image:: https://img.shields.io/pypi/pyversions/crash.svg
-   :target: https://pypi.python.org/pypi/crash/
-   :alt: Python Version
+    :target: https://pypi.python.org/pypi/crash/
+    :alt: Python Version
 
+.. image:: https://img.shields.io/coveralls/crate/crash.svg
+    :target: https://coveralls.io/r/crate/crash?branch=master
+    :alt: Coverage
 
 ========
 Overview

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -3,7 +3,6 @@ develop = .
 extends = versions.cfg
 versions = versions
 show-picked-versions = true
-
 parts = test
         scripts
         crate

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Database'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy, py27, py33, py34
+envlist = pypy, py27, py33, py34, py35, py36
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
* removed pypy3 because it uses Python3.2 which is not supported
* added py36
* added coveralls integration

solves the setuptools problem https://travis-ci.org/crate/crash/jobs/194932264#L276