### PR TITLE
versions: tox and prompt-toolkit

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -26,6 +26,7 @@ zc.customdoctests = 1.0.1
 zc.recipe.egg = 2.0.3
 zc.recipe.testrunner = 2.0.0
 zope.testing = 4.5.0
+prompt-toolkit = 1.0.9
 
 # Required by:
 # Jinja2==2.8

--- a/versions.cfg
+++ b/versions.cfg
@@ -61,7 +61,7 @@ urllib3 = 1.14
 
 # Required by:
 # gp.recipe.tox==0.4
-virtualenv = 14.0.6
+virtualenv = 15.1.0
 
 # Required by:
 # prompt-toolkit==0.59


### PR DESCRIPTION
solves `ERROR: unknown environment 'py35' ` when running bin/tox on jenkins