### PR TITLE
fixed single word statement printing

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for crash
 Unreleased
 ==========
 
+ - Fix: Single word statements (such as ``BEGIN;``) that return ``OK`` crashed
+   the application.
+
  - Expanded the list of keywords used by autocompletion and
    autocapitlization.
 

--- a/src/crate/crash/command.py
+++ b/src/crate/crash/command.py
@@ -351,12 +351,11 @@ class CrateCmd(object):
         if not success:
             return False
         cur = self.cursor
-        command = statement[:re.search("\s", statement).start()].upper()
         duration = ''
         if cur.duration > -1:
             duration = ' ({0:.3f} sec)'.format(float(cur.duration) / 1000.0)
         print_vars = {
-            'command': command,
+            'command': stmt_type(statement),
             'rowcount': cur.rowcount,
             's': 's'[cur.rowcount == 1:],
             'duration': duration
@@ -368,6 +367,13 @@ class CrateCmd(object):
             tmpl = '{command} OK, {rowcount} row{s} affected {duration}'
         self.logger.info(tmpl.format(**print_vars))
         return True
+
+
+def stmt_type(statement):
+    """
+    Extract type of statement, e.g. SELECT, INSERT, UPDATE, DELETE, ...
+    """
+    return re.findall('[\w]+', statement)[0].upper()
 
 
 def get_stdin():

--- a/src/crate/crash/test_command.py
+++ b/src/crate/crash/test_command.py
@@ -11,7 +11,8 @@ from io import TextIOWrapper
 from mock import patch, Mock
 from crate.client.exceptions import ProgrammingError
 
-from .command import CrateCmd, main, get_stdin, noargs_command, Result, host_and_port, get_information_schema_query
+from .command import CrateCmd, main, get_stdin, noargs_command, Result, \
+    host_and_port, get_information_schema_query, stmt_type
 from .outputs import _val_len as val_len, OutputWriter
 from .printer import ColorPrinter
 from .commands import Command
@@ -89,6 +90,17 @@ class CommandLineArgumentsTest(TestCase):
         # default host and default port are used
         self.assertEqual(host_and_port(':'), 'localhost:4200')
 
+
+class CommandUtilsTest(TestCase):
+
+    def test_stmt_type(self):
+        # regular multi word statement
+        self.assertEquals(stmt_type('SELECT 1;'), 'SELECT')
+        # regular single word statement
+        self.assertEquals(stmt_type('BEGIN;'), 'BEGIN')
+        # statements with trailing or leading spaces/tabs/linebreaks
+        self.assertEquals(stmt_type(' SELECT 1 ;'), 'SELECT')
+        self.assertEquals(stmt_type('\nSELECT\n1\n;\n'), 'SELECT')
 
 class CommandTest(TestCase):
 

--- a/src/crate/crash/tests.py
+++ b/src/crate/crash/tests.py
@@ -28,7 +28,8 @@ import zc.customdoctests
 from crate.testing.layer import CrateLayer
 from .command import CrateCmd
 from .printer import ColorPrinter, PrintWrapper
-from .test_command import CommandTest, OutputWriterTest, TestGetInformationSchemaQuery
+from .test_command import CommandTest, CommandLineArgumentsTest, \
+    OutputWriterTest, TestGetInformationSchemaQuery, CommandUtilsTest
 from .test_commands import ReadFileCommandTest, ToggleAutocompleteCommandTest, \
     ChecksCommandTest, ShowTablesCommandTest
 from .test_sysinfo import SysInfoTest
@@ -93,6 +94,8 @@ def test_suite():
     CommandTest.layer = crate_layer
     CommandTest.crate_host = crate_host
     suite.addTest(unittest.makeSuite(CommandTest))
+    suite.addTest(unittest.makeSuite(CommandLineArgumentsTest))
+    suite.addTest(unittest.makeSuite(CommandUtilsTest))
     suite.addTest(unittest.makeSuite(OutputWriterTest))
     suite.addTest(unittest.makeSuite(SysInfoTest))
     suite.addTest(unittest.makeSuite(ReadFileCommandTest))


### PR DESCRIPTION
```
cr> BEGIN;
Traceback (most recent call last):
  File "/mnt/c/Users/mibe/bin/crash", line 24, in <module>
    sys.exit(crate.crash.command.main())
  File "/mnt/d/sandbox/crate/crash/src/crate/crash/command.py", line 464, in main
    loop(cmd, args.history)
  File "/mnt/d/sandbox/crate/crash/src/crate/crash/repl.py", line 312, in loop
    cmd.process(doc.text)
  File "/mnt/d/sandbox/crate/crash/src/crate/crash/command.py", line 242, in process
    self._exec(line)
  File "/mnt/d/sandbox/crate/crash/src/crate/crash/command.py", line 333, in _exec
    success = self.execute(line)
  File "/mnt/d/sandbox/crate/crash/src/crate/crash/command.py", line 354, in execute
    command = statement[:re.search("\s", statement).start()].upper()
AttributeError: 'NoneType' object has no attribute 'start'
```