### PR TITLE
Don't print the whole stack trace on Connection error.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for crash
 Unreleased
 ==========
 
+ - Print only error message instead of full stacktrack in case of connection
+   error.
+
  - Added support for SSL connection to CrateDB.
 
  - Added new parameter ``username`` used to authenticate the user in CrateDB.

--- a/src/crate/crash/command.py
+++ b/src/crate/crash/command.py
@@ -451,7 +451,11 @@ def main():
 
     crate_hosts = [host_and_port(h) for h in args.hosts]
     error_trace = args.verbose > 0
-    cmd = _create_cmd(crate_hosts, error_trace, output_writer, is_tty, args)
+    try:
+        cmd = _create_cmd(crate_hosts, error_trace, output_writer, is_tty, args)
+    except ProgrammingError as e:
+        printer.warn(str(e))
+        sys.exit(1)
 
     if error_trace:
         # log CONNECT command only in verbose mode


### PR DESCRIPTION
It now looks like that:
```
➭ bin/crash -v --verify-ssl true --cert-file /tmp/certs/marios.crt --key-file /tmp/certs/marios.key --ca-cert-file /tmp/certs/rootCA.crt --hosts https://127.0.0.1:4200 -U unknonwn
/Users/matriv/crate/crash/eggs/urllib3-1.14-py3.6.egg/urllib3/connection.py:266: SubjectAltNameWarning: Certificate for 127.0.0.1 has no `subjectAltName`, falling back to check for a `commonName` for now. This feature is being removed by major browsers and deprecated by RFC 2818. (See https://github.com/shazow/urllib3/issues/497 for details.)`
  SubjectAltNameWarning
401 Client Error: Unauthorized
```