### PR TITLE
added support for multiline table headers in the tabular output format

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for crash
 Unreleased
 ==========
 
+ - added support for multiline table headers in the tabular output format
+ 
  - Start autocompletion for non-command keys at the 3rd character.
 
 2017/07/24 0.21.4


### PR DESCRIPTION
```
cr> select 1 = (select 2);
+----------------+
| (1 = (SELECT 2 |
|                |
| ))             |
+----------------+
| FALSE          |
+----------------+
SELECT 1 row in set (0.003 sec)
cr>
```