### PR TITLE
Don't execute lines containing only whitespaces

### DIFF
--- a/src/crate/crash/command.py
+++ b/src/crate/crash/command.py
@@ -187,9 +187,12 @@ def _parse_statements(lines):
 
     >>> list(_parse_statements(['select * from ', 't1;', 'select name']))
     ['select * from t1', 'select name']
+
+    >>> list(_parse_statements(['select * from t1;', '  ']))
+    ['select * from t1']
     """
     lines = (l.strip() for l in lines if l)
-    lines = (l for l in lines if not l.startswith('--'))
+    lines = (l for l in lines if l and not l.startswith('--'))
     parts = []
     for line in lines:
         parts.append(line.rstrip(';'))


### PR DESCRIPTION
A file with trailing whitespace could lead to something like this:

    CONNECT OK
    DROP OK, 1 row affected  (0.058 sec)
    CREATE OK, 1 row affected  (0.193 sec)
    SQLActionException[Failed to parse source [{"stmt": ""}]]