### PR TITLE
Fixed wrong example in environment variables documentation

### DIFF
--- a/docs/cli.txt
+++ b/docs/cli.txt
@@ -98,7 +98,7 @@ other hard-coded cli parameter.
 
 For example::
 
-    $ export CRASHPW=dustins-password
+    $ export CRATEPW=dustins-password
     $ crash --hosts localhost:4200 \
             --username dustin \
             --format json \


### PR DESCRIPTION
Which stated CRASHPW instead of CRATEPW.