### PR TITLE
enabled sitemap generation through sphinx module in the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,1 +1,4 @@
 from crate.theme.rtd.conf.crash import *
+
+site_url = 'https://crate.io/docs/clients/crash/en/latest/'
+extensions = ['sphinx_sitemap']


### PR DESCRIPTION
* added extension to `docs/conf.py`
* set base url in `docs/conf.py`
* this will automatically generate a sitemap for every docs build