### PR TITLE
Bump crate version requirement for schema support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ import re
 requirements = [
     'colorama',
     'Pygments>=2.0',
-    'crate>=0.21.0',
+    'crate>=0.22.0',
     'appdirs>=1.2,<2.0',
     'prompt-toolkit>=1.0,<1.1'
 ]


### PR DESCRIPTION
If `crate` `0.21` is already installed it is not updated, resulting in
an error that `connect` has no argument `schema`.