### PR TITLE
require python3 in standalone bundle

### DIFF
--- a/devtools/bundle.py
+++ b/devtools/bundle.py
@@ -30,7 +30,7 @@ def zipdir(path, zip):
 def main(out_path, libdir):
 
     with open(out_path, 'w') as out_file:
-        out_file.write('#!/usr/bin/env python\n')
+        out_file.write('#!/usr/bin/env python3\n')
         out_file.write('# -*- coding: utf-8 -*-\n')
         out_file.write('# vim: fileencoding=utf-8\n')
 


### PR DESCRIPTION
The shebang `/usr/bin/env python` may execute the bundle with Python 2
which leads to a import error later in the code execution:

```console
$ ./crash_standalone_latest
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "./crash_standalone_latest/__main__.py", line 11, in <module>
  File "./crash_standalone_latest/crate/crash/command.py", line 36, in <module>
  File "./crash_standalone_latest/crate/client/__init__.py", line 22, in <module>
  File "./crash_standalone_latest/crate/client/connection.py", line 24, in <module>
  File "./crash_standalone_latest/crate/client/http.py", line 39, in <module>
ImportError: No module named parse
```

The new shebang will make the give a better message if Python 3 is not
available:

```console
$ ./crash_standalone_latest
/usr/bin/env: ‘python3’: No such file or directory
```