### PR TITLE
Preserve newlines to be able to support line comments properly

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for crash
 Unreleased
 ==========
 
+- Fixed an issue where line comments could only be used at the beginning of a
+  line and not after a partial statement.
+
 2018/06/15 0.24.1
 =================
 

--- a/src/crate/crash/command.py
+++ b/src/crate/crash/command.py
@@ -196,7 +196,7 @@ def _parse_statements(lines):
           Everything after the last ';' will be treated as the last statement.
 
     >>> list(_parse_statements(['select * from ', 't1;', 'select name']))
-    ['select * from t1', 'select name']
+    ['select * from\\nt1', 'select name']
 
     >>> list(_parse_statements(['select * from t1;', '  ']))
     ['select * from t1']
@@ -207,10 +207,10 @@ def _parse_statements(lines):
     for line in lines:
         parts.append(line.rstrip(';'))
         if line.endswith(';'):
-            yield ' '.join(parts)
+            yield '\n'.join(parts)
             parts[:] = []
     if parts:
-        yield ' '.join(parts)
+        yield '\n'.join(parts)
 
 
 class CrateShell:
@@ -297,7 +297,7 @@ class CrateShell:
         if text.startswith('\\'):
             self._try_exec_cmd(text.lstrip('\\'))
         else:
-            for statement in _parse_statements(text.split('\n')):
+            for statement in _parse_statements([text]):
                 self._exec(statement)
 
     def exit(self):


### PR DESCRIPTION
Removing newlines has some unwanted side effects like line comments not
terminating at the end of the line anymore.