### PR TITLE
Reset the buffer on Ctrl+c

### DIFF
--- a/src/crate/crash/repl.py
+++ b/src/crate/crash/repl.py
@@ -361,6 +361,7 @@ def loop(cmd, history_file):
                 cmd.logger.warn(str(e))
         except KeyboardInterrupt:
             cmd.logger.warn("Query not cancelled. Run KILL <jobId> to cancel it")
+            buf.reset()
         except EOFError:
             cmd.logger.warn('Bye!')
             return


### PR DESCRIPTION
If you're writing a query and hit `Ctrl+c` it now resets the input
buffer, so that you can start over.