### PR TITLE
Drop Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 cache: pip
 python:
-    - 3.4
     - 3.5
     - 3.6
+    - 3.7
     - pypy3
     - nightly
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for crash
 Unreleased
 ==========
 
+- Dropped support for Python 3.4 and added official support for Python 3.7
+
 2018/10/04 0.24.2
 =================
 

--- a/README.rst
+++ b/README.rst
@@ -50,15 +50,15 @@ To update, run::
 
      $ pip install -U crash
 
-If you are not using Python version 3.4 or above, recent version of `pip`_ will
-only install version 0.23.x. This is because newer versions of this package are
-not compatible with Python 2.7 or 3.3 and below.
+If you are not using Python version 3.5 or above, recent version of `pip`_ will
+install an earlier version of Crash. This is because newer versions of this
+package are not compatible with Python 2.7 or 3.4 and below.
 
 Standalone
 ----------
 
 Crash is also available as a standalone executable that includes all the
-necessary dependencies, and can be run as long as Python (>= 3.4) is available
+necessary dependencies, and can be run as long as Python (>= 3.5) is available
 on your system.
 
 First, download the executable file::

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
         ],
         argcompletion=['argcomplete']
     ),
-    python_requires='>=3.4',
+    python_requires='>=3.5',
     install_requires=requirements,
     package_data={'': ['*.txt']},
     classifiers=[
@@ -87,9 +87,9 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Database'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy3, py34, py35, py36
+envlist = pypy3, py35, py36, py37
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
Some of the newer versions of our dependencies dropped support for
Python 3.4.

Python 3.4 has reached end of life and according to
https://en.wikipedia.org/wiki/CPython#Enterprise_Linux only Debian 8
shipped Python 3.4 to begin with.