### PR TITLE
Apply and enforce isort on codebase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ before_install:
   - sudo apt-get install -y openjdk-12-jdk
 
 install:
-    - pip install ".[test]"
-    - pip install coverage flake8
+    - pip install ".[test,devel]"
 
 script:
+    - isort --recursive --check --diff crate/ tests/ setup.py
     - flake8 crate/crash
     - coverage run -m unittest -v
 

--- a/crate/crash/command.py
+++ b/crate/crash/command.py
@@ -28,25 +28,26 @@ import logging
 import os
 import re
 import sys
-import urllib3
-
-from appdirs import user_data_dir, user_config_dir
 from argparse import ArgumentParser, ArgumentTypeError
 from collections import namedtuple
-from crate.client import connect
-from crate.client.exceptions import ConnectionError, ProgrammingError
 from distutils.version import StrictVersion
 from getpass import getpass
 from logging import NullHandler
 from operator import itemgetter
+
+import urllib3
+from appdirs import user_config_dir, user_data_dir
 from urllib3.exceptions import LocationParseError
 
-from .commands import built_in_commands, Command
+from crate.client import connect
+from crate.client.exceptions import ConnectionError, ProgrammingError
+
+from ..crash import __version__ as crash_version
+from .commands import Command, built_in_commands
 from .config import Configuration, ConfigurationError
 from .outputs import OutputWriter
 from .printer import ColorPrinter, PrintWrapper
 from .sysinfo import SysInfoCommand
-from ..crash import __version__ as crash_version
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 logging.getLogger('crate').addHandler(NullHandler())

--- a/crate/crash/commands.py
+++ b/crate/crash/commands.py
@@ -19,9 +19,8 @@
 
 import functools
 import os
-
-from distutils.version import StrictVersion
 from collections import OrderedDict
+from distutils.version import StrictVersion
 
 
 class Command(object):

--- a/crate/crash/config.py
+++ b/crate/crash/config.py
@@ -23,11 +23,12 @@
 
 
 import os
+from functools import partial
+
 try:
     import configparser
 except ImportError:
     import ConfigParser as configparser
-from functools import partial
 
 
 class ConfigurationError(Exception):

--- a/crate/crash/keybinding.py
+++ b/crate/crash/keybinding.py
@@ -22,8 +22,9 @@
 
 
 import re
-from prompt_toolkit.keys import Keys
+
 from prompt_toolkit.filters import Condition
+from prompt_toolkit.keys import Keys
 
 TAB_WIDTH = 4
 WHITESPACE_RE = re.compile(r'\s+$')

--- a/crate/crash/layout.py
+++ b/crate/crash/layout.py
@@ -21,35 +21,21 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
-from prompt_toolkit.filters import (
-    is_done,
-    has_focus,
-    renderer_height_is_known
-)
+from prompt_toolkit.application import get_app
 from prompt_toolkit.enums import DEFAULT_BUFFER, SEARCH_BUFFER
-from prompt_toolkit.layout import (
-    Layout,
-    Window,
-    WindowAlign,
-    HSplit,
-    VSplit,
-    Float
-)
-from prompt_toolkit.layout.containers import (
-    ConditionalContainer,
-    FloatContainer
-)
+from prompt_toolkit.filters import has_focus, is_done, renderer_height_is_known
+from prompt_toolkit.layout import Float, HSplit, Layout, VSplit, Window, WindowAlign
+from prompt_toolkit.layout.containers import ConditionalContainer, FloatContainer
+from prompt_toolkit.layout.controls import BufferControl, FormattedTextControl
 from prompt_toolkit.layout.dimension import Dimension
-from prompt_toolkit.layout.controls import FormattedTextControl, BufferControl
-from prompt_toolkit.lexers import PygmentsLexer
+from prompt_toolkit.layout.margins import ConditionalMargin, PromptMargin
 from prompt_toolkit.layout.menus import CompletionsMenu
 from prompt_toolkit.layout.processors import (
     ConditionalProcessor,
-    HighlightSearchProcessor
+    HighlightSearchProcessor,
 )
+from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.widgets import SearchToolbar
-from prompt_toolkit.layout.margins import PromptMargin, ConditionalMargin
-from prompt_toolkit.application import get_app
 
 
 def create_layout(buffer,

--- a/crate/crash/outputs.py
+++ b/crate/crash/outputs.py
@@ -2,12 +2,12 @@ import csv
 import json
 import sys
 
-from pygments import highlight
-from pygments.lexers.data import JsonLexer
-from pygments.formatters import TerminalFormatter
 from colorama import Fore, Style
+from pygments import highlight
+from pygments.formatters import TerminalFormatter
+from pygments.lexers.data import JsonLexer
 
-from .tabulate import TableFormat, Line as TabulateLine, DataRow, tabulate, float_format
+from .tabulate import DataRow, Line as TabulateLine, TableFormat, float_format, tabulate
 
 if sys.version_info[:2] == (2, 6):
     OrderedDict = dict

--- a/crate/crash/printer.py
+++ b/crate/crash/printer.py
@@ -23,7 +23,8 @@
 from __future__ import print_function
 
 import sys
-from colorama import init, Fore, Style
+
+from colorama import Fore, Style, init
 
 init(autoreset=True)
 

--- a/crate/crash/repl.py
+++ b/crate/crash/repl.py
@@ -22,40 +22,44 @@
 
 import os
 import re
-
-from pygments.lexers.sql import PostgresLexer
-from pygments.style import Style
-from prompt_toolkit.output.defaults import get_default_output
-from prompt_toolkit.styles.pygments import style_from_pygments_cls
-from pygments.token import (Keyword,
-                            Comment,
-                            Operator,
-                            Name,
-                            Number,
-                            String,
-                            Error,
-                            Token)
-
-from prompt_toolkit.completion import Completer, Completion
-from prompt_toolkit.history import FileHistory
-from prompt_toolkit.buffer import Buffer
-from prompt_toolkit.filters import Condition, IsDone, HasFocus
-from prompt_toolkit import Application
-from prompt_toolkit.enums import DEFAULT_BUFFER, EditingMode
-from prompt_toolkit.formatted_text import PygmentsTokens
-from prompt_toolkit.key_binding import KeyBindings, merge_key_bindings
-from prompt_toolkit.key_binding.bindings.open_in_editor import load_open_in_editor_bindings
-from prompt_toolkit.layout.processors import (
-    HighlightMatchingBracketProcessor,
-    ConditionalProcessor
-)
-from prompt_toolkit.application import get_app
-from crate.client.exceptions import ProgrammingError
 from getpass import getpass
 
+from prompt_toolkit import Application
+from prompt_toolkit.application import get_app
+from prompt_toolkit.buffer import Buffer
+from prompt_toolkit.completion import Completer, Completion
+from prompt_toolkit.enums import DEFAULT_BUFFER, EditingMode
+from prompt_toolkit.filters import Condition, HasFocus, IsDone
+from prompt_toolkit.formatted_text import PygmentsTokens
+from prompt_toolkit.history import FileHistory
+from prompt_toolkit.key_binding import KeyBindings, merge_key_bindings
+from prompt_toolkit.key_binding.bindings.open_in_editor import (
+    load_open_in_editor_bindings,
+)
+from prompt_toolkit.layout.processors import (
+    ConditionalProcessor,
+    HighlightMatchingBracketProcessor,
+)
+from prompt_toolkit.output.defaults import get_default_output
+from prompt_toolkit.styles.pygments import style_from_pygments_cls
+from pygments.lexers.sql import PostgresLexer
+from pygments.style import Style
+from pygments.token import (
+    Comment,
+    Error,
+    Keyword,
+    Name,
+    Number,
+    Operator,
+    String,
+    Token,
+)
+
+from crate.client.exceptions import ProgrammingError
+
 from .commands import Command
-from .layout import create_layout
 from .keybinding import bind_keys
+from .layout import create_layout
 
 MAX_HISTORY_LENGTH = 10000
 

--- a/crate/crash/sysinfo.py
+++ b/crate/crash/sysinfo.py
@@ -24,7 +24,6 @@
 from collections import namedtuple
 from distutils.version import StrictVersion
 
-
 Result = namedtuple('Result', ['rows', 'cols'])
 SYSINFO_MIN_VERSION = StrictVersion("0.54.0")
 

--- a/crate/crash/tabulate.py
+++ b/crate/crash/tabulate.py
@@ -22,12 +22,11 @@
 
 """Pretty-print tabular data."""
 
-import re
 import io
+import re
 from collections import namedtuple
+from functools import partial, reduce
 from itertools import zip_longest as izip_longest
-from functools import reduce, partial
-
 
 _none_type = type(None)
 _int_type = int

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,12 @@ ignore = E501, W503
 
 [pydocstyle]
 ignore = D107, D203, D213
+
+[isort]
+combine_as_imports = true
+default_section = THIRDPARTY
+include_trailing_comma = true
+known_first_party = crate,tests
+line_length = 88
+multi_line_output = 3
+not_skip = __init__.py

--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,11 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
-from setuptools import setup
-import os
 import io
+import os
 import re
 
+from setuptools import setup
 
 requirements = [
     'colorama',
@@ -74,6 +74,11 @@ setup(
         test=[
             'crate[test]',
             'zc.customdoctests'
+        ],
+        devel=[
+            'coverage',
+            'flake8',
+            'isort',
         ],
         argcompletion=['argcomplete']
     ),

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
 # vim: set fileencodings=utf-8
 
+from distutils.version import StrictVersion
 from unittest import TestCase
 
 from crate.crash.command import (
     Result,
+    get_information_schema_query,
     host_and_port,
     stmt_type,
-    get_information_schema_query
 )
 from crate.crash.outputs import OutputWriter
-from distutils.version import StrictVersion
 
 
 class OutputWriterTest(TestCase):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -22,20 +22,20 @@
 import os
 import shutil
 import tempfile
-
-from unittest import TestCase
-from unittest.mock import patch, MagicMock
 from distutils.version import StrictVersion
-from crate.crash.commands import (
-    ReadFileCommand,
-    ToggleAutocompleteCommand,
-    ToggleAutoCapitalizeCommand,
-    ToggleVerboseCommand,
-    NodeCheckCommand,
-    ClusterCheckCommand,
-    CheckCommand
-)
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
 from crate.crash.command import CrateShell
+from crate.crash.commands import (
+    CheckCommand,
+    ClusterCheckCommand,
+    NodeCheckCommand,
+    ReadFileCommand,
+    ToggleAutoCapitalizeCommand,
+    ToggleAutocompleteCommand,
+    ToggleVerboseCommand,
+)
 
 
 class ReadFileCommandTest(TestCase):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,12 +19,13 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+import configparser
 import os
 import tempfile
-import configparser
 from unittest import TestCase
+
+from crate.crash.command import CONFIG_PATH, parse_config_path
 from crate.crash.config import Configuration, ConfigurationError
-from crate.crash.command import parse_config_path, CONFIG_PATH
 
 
 class ConfigurationTest(TestCase):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,30 +1,29 @@
-import sys
 import os
-import tempfile
 import re
 import ssl
-from unittest.mock import patch, Mock
-from io import TextIOWrapper, StringIO
-
-from unittest import TestCase
+import sys
+import tempfile
 from doctest import testfile
+from io import StringIO, TextIOWrapper
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
 from urllib3.exceptions import LocationParseError
 
 from crate.client.exceptions import ProgrammingError
-from crate.testing.layer import CrateLayer
-
-from crate.crash.commands import Command
-from crate.crash.printer import ColorPrinter
-from crate.crash.outputs import _val_len as val_len
 from crate.crash.command import (
     CrateShell,
-    main,
-    get_stdin,
-    noargs_command,
-    host_and_port,
     _create_shell,
-    get_parser
+    get_parser,
+    get_stdin,
+    host_and_port,
+    main,
+    noargs_command,
 )
+from crate.crash.commands import Command
+from crate.crash.outputs import _val_len as val_len
+from crate.crash.printer import ColorPrinter
+from crate.testing.layer import CrateLayer
 
 crate_http_port = 44209
 crate_transport_port = 44309

--- a/tests/test_keybinding.py
+++ b/tests/test_keybinding.py
@@ -18,12 +18,17 @@
 # software solely pursuant to the terms of the relevant commercial agreement.
 
 from unittest import TestCase
-from prompt_toolkit.document import Document
-from prompt_toolkit.keys import Keys
-from prompt_toolkit.buffer import Buffer
-from prompt_toolkit.key_binding import KeyBindings
-from crate.crash.keybinding import bind_keys, _is_start_of_multiline, _line_ends_with_tab
 
+from prompt_toolkit.buffer import Buffer
+from prompt_toolkit.document import Document
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.keys import Keys
+
+from crate.crash.keybinding import (
+    _is_start_of_multiline,
+    _line_ends_with_tab,
+    bind_keys,
+)
 
 doc = lambda t: Document(t, len(t))
 is_start_of_multiline = lambda t: _is_start_of_multiline(doc(t))

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -19,12 +19,18 @@
 
 import re
 from unittest import TestCase
+
 from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.document import Document
 from pygments.token import Token
 
-from crate.crash.repl import SQLCompleter, Capitalizer, create_buffer, _get_toolbar_tokens
-from crate.crash.command import CrateShell, ConnectionMeta
+from crate.crash.command import ConnectionMeta, CrateShell
+from crate.crash.repl import (
+    Capitalizer,
+    SQLCompleter,
+    _get_toolbar_tokens,
+    create_buffer,
+)
 
 
 class SQLCompleterTest(TestCase):

--- a/tests/test_sysinfo.py
+++ b/tests/test_sysinfo.py
@@ -21,12 +21,12 @@
 # software solely pursuant to the terms of the relevant commercial agreement.
 
 
+from distutils.version import StrictVersion
 from unittest import TestCase
-from unittest.mock import patch, PropertyMock
+from unittest.mock import PropertyMock, patch
 
 from crate.crash.command import CrateShell
-from crate.crash.sysinfo import SysInfoCommand, Result as Res
-from distutils.version import StrictVersion
+from crate.crash.sysinfo import Result as Res, SysInfoCommand
 
 CRATE_VERSION = StrictVersion("0.55.2")
 assert CrateShell, "Used for patch"


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Using [`isort`](https://pypi.org/project/isort/) for consistent import ordering and formatting.