### PR TITLE
Added `beep` command to toggle console beeping upon SQL command completion

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,8 @@ Unreleased
 
 - Dropped support for Python 3.4 and added official support for Python 3.7
 
+- Added an option to output a beep to the console upon the completion of SQL queries
+
 2018/10/04 0.24.2
 =================
 

--- a/crate/crash/command.py
+++ b/crate/crash/command.py
@@ -118,6 +118,10 @@ def get_parser(output_formats=[], conf=None):
                         dest='autocapitalize',
                         default=False,
                         help='enable automatic capitalization of SQL keywords while typing')
+    parser.add_argument('-b', '--beep', action='store_true',
+                        dest='beep',
+                        default=False,
+                        help='enable console beep upon conclusion of SQL queries')
     parser.add_argument('-U', '--username', type=str, metavar='USERNAME',
                         help='Authenticate as USERNAME.')
     parser.add_argument('-W', '--password', action='store_true',
@@ -211,6 +215,7 @@ class CrateShell:
                  is_tty=True,
                  autocomplete=True,
                  autocapitalize=True,
+                 beep=False,
                  verify_ssl=True,
                  cert_file=None,
                  key_file=None,
@@ -238,6 +243,7 @@ class CrateShell:
         self.error_trace = error_trace
         self._autocomplete = autocomplete
         self._autocapitalize = autocapitalize
+        self._beep = beep
         self.verify_ssl = verify_ssl
         self.cert_file = cert_file
         self.key_file = key_file
@@ -266,6 +272,9 @@ class CrateShell:
 
     def should_autocapitalize(self):
         return self._autocapitalize
+
+    def should_beep(self):
+        return self._beep
 
     def pprint(self, rows, cols):
         result = Result(cols,
@@ -478,6 +487,8 @@ class CrateShell:
         else:
             tmpl = '{command} OK, {rowcount} row{s} affected {duration}'
         self.logger.info(tmpl.format(**print_vars))
+        if self.should_beep():
+            sys.stdout.write('\a')
         return True
 
 
@@ -626,6 +637,7 @@ def _create_shell(crate_hosts, error_trace, output_writer, is_tty, args,
                       is_tty=is_tty,
                       autocomplete=args.autocomplete,
                       autocapitalize=args.autocapitalize,
+                      beep=args.beep,
                       verify_ssl=args.verify_ssl,
                       cert_file=args.cert_file,
                       key_file=args.key_file,

--- a/crate/crash/commands.py
+++ b/crate/crash/commands.py
@@ -226,6 +226,17 @@ class CheckCommand(Command):
             cmd.logger.warn('No check for {}'.format(check_name))
 
 
+class ToggleBeepCommand(Command):
+    """ toggle beep upon completion of SQL queries """
+
+    @noargs_command
+    def __call__(self, cmd, *args, **kwargs):
+        cmd._beep = not cmd._beep
+        return 'Beep {0}'.format(
+            cmd._beep and 'ON' or 'OFF'
+        )
+
+
 built_in_commands = {
     '?': HelpCommand(),
     'r': ReadFileCommand(),
@@ -234,4 +245,5 @@ built_in_commands = {
     'autocapitalize': ToggleAutoCapitalizeCommand(),
     'verbose': ToggleVerboseCommand(),
     'check': CheckCommand(),
+    'beep': ToggleBeepCommand()
 }

--- a/docs/commands.txt
+++ b/docs/commands.txt
@@ -64,3 +64,8 @@ Every command starts with a ``\`` character.
 |                        |                                                     |
 |                        | Works as a toggle.                                  |
 +------------------------+-----------------------------------------------------+
+| ``\beep``              | Turn on console beeping upon the completion of SQL  |
+|                        | queries.                                            |
+|                        |                                                     |
+|                        | Works as a toggle.                                  |
++------------------------+-----------------------------------------------------+

--- a/docs/run.txt
+++ b/docs/run.txt
@@ -90,6 +90,12 @@ The ``crash`` executable supports multiple command-line options:
 |                               | This feature is experimental and may be      |
 |                               | removed in future versions.                  |
 +-------------------------------+----------------------------------------------+
+| | ``-b`` ,                    | Enable console beeping upon the completion   |
+| | ``--beep``                  | of SQL queries.                              |
+|                               |                                              |
+|                               | This can be useful when the user wants to be |
+|                               | notified at the end of a long running query. |
++-------------------------------+----------------------------------------------+
 | ``--verify-ssl``              | Force the verification of the server SSL     |
 |                               | certificate.                                 |
 +-------------------------------+----------------------------------------------+

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -34,6 +34,7 @@ from crate.crash.commands import (
     ReadFileCommand,
     ToggleAutoCapitalizeCommand,
     ToggleAutocompleteCommand,
+    ToggleBeepCommand,
     ToggleVerboseCommand,
 )
 
@@ -124,6 +125,18 @@ class ToggleVerboseCommandTest(TestCase):
         output = command(fake_cmd)
         self.assertEqual(output, 'Verbose ON')
         self.assertEqual(fake_cmd.reconnect.call_count, 1)
+
+
+class ToggleBeepCommandTest(TestCase):
+
+    @patch('crate.crash.command.CrateShell')
+    def test_toggle_output(self, fake_cmd):
+        fake_cmd._beep = True
+        command = ToggleBeepCommand()
+        output = command(fake_cmd)
+        self.assertEqual(output, 'Beep OFF')
+        output = command(fake_cmd)
+        self.assertEqual(output, 'Beep ON')
 
 
 class ShowTablesCommandTest(TestCase):


### PR DESCRIPTION
##  Summary of the changes / Why this is an improvement

I've found that having a console beep at the conclusion of a long
running SQL query came in really useful for multitasking. I would
usually do this through the pattern of:

```
crash -c "select * from sys.summits;" && echo -e "\a"
```

This PR adds a command that lets crash do this instead, by sending the
bell character to the console.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
