### PR TITLE
Update config module name

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-from crate.theme.rtd.conf.crash import *
+from crate.theme.rtd.conf.clients_crash import *
 
 site_url = 'https://crate.io/docs/clients/crash/en/latest/'
 extensions = ['sphinx_sitemap']

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 # don't pin crate version numbers so the latest will always be pulled when you
 # set up your environment from scratch
 
-crate-docs-theme
+crate-docs-theme>=0.7
 
 # packages for local dev
 


### PR DESCRIPTION
the upstream name has changed in most recently docs theme package

- [ ] add min version for theme (https://github.com/crate/crash/pull/309#discussion_r339545930)
- [ ] sort backports (https://github.com/crate/crate/pull/9302#issuecomment-546934088)