### PR TITLE
Add official support for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
     - 3.5
     - 3.6
     - 3.7
+    - 3.8
     - pypy3
     - nightly
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for crash
 Unreleased
 ==========
 
+- Added official support for Python 3.8.
+
 - Added the cluster name to the status bar.
 
 - Sort the output of the ``\dt`` (show tables) command alphabetically.

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Database'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy3, py35, py36, py37
+envlist = pypy3, py35, py36, py37, py38
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Python 3.8 has been released on Oct 14, 2019
https://www.python.org/dev/peps/pep-0569/#id6


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
