### PR TITLE
Fix ctrl+r search cancelling not returning focus

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,11 @@
 Changes for crash
 =================
 
+Unreleased
+==========
+
+- Fixed issue where cancelling a ctrl-r search would not return focus.
+
 2020/03/04 0.25.0
 =================
 

--- a/crate/crash/repl.py
+++ b/crate/crash/repl.py
@@ -36,6 +36,7 @@ from prompt_toolkit.key_binding import KeyBindings, merge_key_bindings
 from prompt_toolkit.key_binding.bindings.open_in_editor import (
     load_open_in_editor_bindings,
 )
+from prompt_toolkit.layout.controls import SearchBufferControl
 from prompt_toolkit.layout.processors import (
     ConditionalProcessor,
     HighlightMatchingBracketProcessor,
@@ -368,8 +369,11 @@ def loop(cmd, history_file):
             else:
                 cmd.logger.warn(str(e))
         except KeyboardInterrupt:
-            cmd.logger.warn("Query not cancelled. Run KILL <jobId> to cancel it")
-            buf.reset()
+            if isinstance(app.layout.current_control, SearchBufferControl):
+                app.layout.current_control = app.layout.previous_control
+            else:
+                cmd.logger.warn("Query not cancelled. Run KILL <jobId> to cancel it")
+                buf.reset()
         except EOFError:
             cmd.logger.warn('Bye!')
             return


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

When in vi-mode, pressing ctrl+r starts the search mode. We would expect
that pressing ctrl+c to close the search mode would return focus back to
the text input, but this never happened.

What was happening is that, when you press ctrl-r, a new control element
is created called a SearchBufferControl, which is then focused on.
Pressing esc closes this control, and returns focus to the previous
control (the one created by our default text buffer).

For some reason, the keyboard interrupt exception isn't caught by this
control, and is instead bubbled up to our application. Consequently,
this SearchBufferControl remains in focus and cannot be escaped.

This PR sets it so that when a KeyboardInterrupt is caught and the
current buffer control is a search buffer control, focus is instead
given back to the previous control. This should address #320

I'm not sure if this is a bug with the prompt toolkit or not. Will look
into it further.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
