### PR TITLE
Upgrade docs to use standard crate-docs-build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
+.coverage
+.crate-docs-build
 .idea/
 .installed.cfg
+.mypy_cache/
 .tox/
 .venv/
-venv/
-.coverage
 *.DS_Store
 *.egg-info
 *.iml
@@ -16,5 +17,4 @@ dist/
 eggs/
 out/
 parts/
-.mypy_cache/
-
+venv/

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -151,7 +151,9 @@ To make changes to the RTD configuration (e.g., to activate or deactivate a
 release version), please contact the `@crate/tech-writing`_ team.
 
 
-... _@crate/tech-writing: https://github.com/orgs/crate/teams/tech-writing
+.. _@crate/tech-writing: https://github.com/orgs/crate/teams/tech-writing
+.. _configured: https://github.com/crate/crash/blob/master/.travis.yml
+.. _fswatch: https://github.com/emcrisostomo/fswatch
 .. _Jenkins: http://jenkins-ci.org/
 .. _PyPI: https://pypi.python.org/pypi
 .. _Read the Docs: http://readthedocs.org/
@@ -161,8 +163,6 @@ release version), please contact the `@crate/tech-writing`_ team.
 .. _twine: https://pypi.python.org/pypi/twine
 .. _versions: https://readthedocs.org/projects/crash/versions/
 .. _zope.testrunner: https://pypi.python.org/pypi/zope.testrunner/4.4.1
-.. _fswatch: https://github.com/emcrisostomo/fswatch
-.. _configured: https://github.com/crate/crash/blob/master/.travis.yml
 
 
 .. |build| image:: https://img.shields.io/endpoint.svg?color=blue&url=https%3A%2F%2Fraw.githubusercontent.com%2Fcrate%2Fcrash%2Fmaster%2Fdocs%2Fbuild.json

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -88,8 +88,6 @@ For help, run:
 
       check   Build, test, and lint the documentation
 
-      delint  Remove any `*.lint` files
-
       reset   Reset the build cache
 
 You must install `fswatch`_ to use the ``dev`` target.

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -2,6 +2,7 @@
 Developer Guide
 ===============
 
+
 Setup
 =====
 
@@ -13,6 +14,7 @@ Create a virtualenv and install the project::
 Afterwards you can launch crash::
 
     $ venv/bin/crash
+
 
 Running Tests
 =============
@@ -33,6 +35,7 @@ To run against a single interpreter, you can also do::
 
     $ venv/bin/tox -e py33
 
+
 Standalone Executable
 =====================
 
@@ -43,6 +46,66 @@ To build a standalone executable, you can use shiv_::
 Run the executable like so::
 
     $ ./crash.pyz
+
+
+Standalone Deployment
+=====================
+
+The standalone executable is built and deployed by a `Jenkins`_ job.
+
+
+Documentation
+=============
+
+The documentation is written using `Sphinx`_ and `ReStructuredText`_.
+
+
+Working on the documentation
+----------------------------
+
+Python 3.7 is required.
+
+Change into the ``docs`` directory:
+
+.. code-block:: console
+
+    $ cd docs
+
+For help, run:
+
+.. code-block:: console
+
+    $ make
+
+    Crate Docs Build
+
+    Run `make <TARGET>`, where <TARGET> is one of:
+
+      dev     Run a Sphinx development server that builds and lints the
+              documentation as you edit the source files
+
+      html    Build the static HTML output
+
+      check   Build, test, and lint the documentation
+
+      delint  Remove any `*.lint` files
+
+      reset   Reset the build cache
+
+You must install `fswatch`_ to use the ``dev`` target.
+
+
+Continuous integration and deployment
+-------------------------------------
+
+|build| |travis| |rtd|
+
+Travis CI is `configured`_ to run ``make check`` from the ``docs`` directory.
+Please do not merge pull requests until the tests pass.
+
+`Read the Docs`_ (RTD) automatically deploys the documentation whenever a
+configured branch is updated.
+
 
 Preparing a Release
 ===================
@@ -68,7 +131,7 @@ To create a new release, you must:
 Archiving Docs Versions
 -----------------------
 
-Check the `versions hosted on ReadTheDocs`_.
+Check the `versions`_ hosted on ReadTheDocs.
 
 We should only be hosting the docs for ``latest``, the last three minor release
 branches of the last major release, and the last minor release branch
@@ -85,38 +148,31 @@ Because this project has not yet had a major release, as of yet, there are no
 major releases before ``0`` to include in this list.
 
 To make changes to the RTD configuration (e.g., to activate or deactivate a
-release version), please contact the `@crate/docs`_ team.
-
-Standalone Deployment
-=====================
-
-The standalone executable is built and deployed by a `Jenkins`_ job.
+release version), please contact the `@crate/tech-writing`_ team.
 
 
-Writing Documentation
-=====================
-
-The docs live under the ``docs`` directory.
-
-The docs are written written with `ReStructuredText`_ and processed with
-`Sphinx`_.
-
-Build the docs by running::
-
-    $ bin/sphinx
-
-The output can then be found in the ``out/html`` directory.
-
-The docs are automatically built from Git by `Read the Docs`_ and there is
-nothing special you need to do to get the live docs to update.
-
-.. _@crate/docs: https://github.com/orgs/crate/teams/docs
+... _@crate/tech-writing: https://github.com/orgs/crate/teams/tech-writing
 .. _Jenkins: http://jenkins-ci.org/
 .. _PyPI: https://pypi.python.org/pypi
-.. _Read the Docs: http://readthedocs.org
+.. _Read the Docs: http://readthedocs.org/
 .. _ReStructuredText: http://docutils.sourceforge.net/rst.html
 .. _Sphinx: http://sphinx-doc.org/
 .. _tox: http://testrun.org/tox/latest/
 .. _twine: https://pypi.python.org/pypi/twine
-.. _versions hosted on ReadTheDocs: https://readthedocs.org/projects/crash/versions/
+.. _versions: https://readthedocs.org/projects/crash/versions/
 .. _zope.testrunner: https://pypi.python.org/pypi/zope.testrunner/4.4.1
+.. _fswatch: https://github.com/emcrisostomo/fswatch
+.. _configured: https://github.com/crate/crash/blob/master/.travis.yml
+
+
+.. |build| image:: https://img.shields.io/endpoint.svg?color=blue&url=https%3A%2F%2Fraw.githubusercontent.com%2Fcrate%2Fcrash%2Fmaster%2Fdocs%2Fbuild.json
+    :alt: Build version
+    :target: https://github.com/crate/crash/blob/master/docs/build.json
+
+.. |travis| image:: https://img.shields.io/travis/crate/crash.svg?style=flat
+    :alt: Travis CI status
+    :target: https://travis-ci.org/crate/crash
+
+.. |rtd| image:: https://readthedocs.org/projects/crash/badge/?version=latest
+    :alt: Read The Docs status
+    :target: https://readthedocs.org/projects/crash

--- a/README.rst
+++ b/README.rst
@@ -10,10 +10,6 @@ The CrateDB Shell
     :target: http://badge.fury.io/py/crash
     :alt: Version
 
-.. image:: https://img.shields.io/badge/docs-latest-brightgreen.svg
-    :target: https://crate.io/docs/reference/crash/
-    :alt: Documentation
-
 .. image:: https://coveralls.io/repos/github/crate/crash/badge.svg?branch=master
     :target: https://coveralls.io/github/crate/crash?branch=master
     :alt: Coverage

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,73 @@
+# Licensed to Crate (https://crate.io) under one or more contributor license
+# agreements.  See the NOTICE file distributed with this work for additional
+# information regarding copyright ownership.  Crate licenses this file to you
+# under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# However, if you have executed another commercial license agreement with Crate
+# these terms will supersede the license and you may use the software solely
+# pursuant to the terms of the relevant commercial agreement.
+
+
+# Do not edit anything below this line
+###############################################################################
+
+.EXPORT_ALL_VARIABLES:
+
+DOCS_DIR      := docs
+TOP_DIR       := ..
+BUILD_JSON    := build.json
+BUILD_REPO    := https://github.com/crate/crate-docs-build.git
+CLONE_DIR     := .crate-docs-build
+SRC_DIR       := $(CLONE_DIR)/src
+SELF_SRC      := $(TOP_DIR)/src
+SELF_MAKEFILE := $(SELF_SRC)/rules.mk
+SRC_MAKE      := $(MAKE) -f $(SRC_DIR)/rules.mk
+
+# Parse the JSON file
+BUILD_VERSION = $(shell cat $(BUILD_JSON) | \
+    python -c 'import json, sys; print(json.load(sys.stdin)["message"])')
+
+ifeq ($(BUILD_VERSION),)
+$(error No version specified in $(BUILD_JSON))
+endif
+
+# Default rule
+.PHONY: help
+help: $(CLONE_DIR)
+	@ $(SRC_MAKE) $@
+
+ifneq ($(wildcard $(SELF_MAKEFILE)),)
+# The project detects itself and fakes an install of its own core build rules
+# so that it can test itself
+$(CLONE_DIR):
+	mkdir -p $@
+	cp -R $(SELF_SRC) $(SRC_DIR)
+else
+# All other projects install a versioned copy of the core build rules
+$(CLONE_DIR):
+	git clone --depth=1 -c advice.detachedHead=false \
+	    --branch=$(BUILD_VERSION) $(BUILD_REPO) $(CLONE_DIR)
+endif
+
+# Don't pass through this target
+.PHONY: Makefile
+Makefile:
+
+# By default, pass targets through to the core build rules
+.PHONY:
+%: $(CLONE_DIR)
+	@ $(SRC_MAKE) $@
+
+.PHONY: reset
+reset:
+	rm -rf $(CLONE_DIR)

--- a/docs/build.json
+++ b/docs/build.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 1,
+  "label": "docs build",
+  "message": "0.3.2"
+}

--- a/docs/docutils.conf
+++ b/docs/docutils.conf
@@ -1,3 +1,0 @@
-[html4css1 writer]
-field_name_limit: 40
-

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,14 +1,1 @@
-# don't pin crate version numbers so the latest will always be pulled when you
-# set up your environment from scratch
-
-crate-docs-theme>=0.7
-
-# packages for local dev
-
-sphinx-autobuild==0.6.0
-
-# the next section should mirror the RTD environment
-
-alabaster>=0.7,<0.8,!=0.7.5
-setuptools<41
-sphinx==1.7.4
+crate-docs-theme


### PR DESCRIPTION
this PR switches docs build to https://github.com/crate/crate-docs-build