### PR TITLE
Upgrade CrateDB python driver to 0.26.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,12 @@ Changes for crash
 Unreleased
 ==========
 
+Changes
+=======
+
+- Upgraded the CrateDB python driver to 0.26.0 in order to enable TCP keepalive
+  on the socket level.
+
 2020/09/21 0.26.0
 =================
 

--- a/crate/crash/command.py
+++ b/crate/crash/command.py
@@ -345,7 +345,11 @@ class CrateShell:
                                   username=self.username,
                                   password=self.password,
                                   schema=self.schema,
-                                  timeout=self.timeout)
+                                  timeout=self.timeout,
+                                  socket_keepalive=True,
+                                  socket_tcp_keepidle=120,
+                                  socket_tcp_keepintvl=30,
+                                  socket_tcp_keepcnt=8)
         self.cursor = self.connection.cursor()
         self._fetch_session_info()
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from setuptools import setup
 requirements = [
     'colorama',
     'Pygments>=2.4',
-    'crate>=0.22.0',
+    'crate>=0.26.0',
     'appdirs>=1.2,<2.0',
     'prompt-toolkit>=2.0,<3.0'
 ]


### PR DESCRIPTION
@chaudum As I understand, the TCP keepalive is enabled by default, so just upgrading the python driver should add it. Do you think it would be worth explicitly setting it to true for clarity's sake?