### PR TITLE
Upgrade to new docs build 0.4.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,25 @@
+name: docs
+on:
+  pull_request: ~
+  push:
+    branches:
+      - master
+
+jobs:
+  documentation:
+    name: Build docs on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Build docs
+        run: |
+          cd docs && make check

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .coverage
-.crate-docs-build
+.crate-docs
 .idea/
 .installed.cfg
 .mypy_cache/

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,15 @@
+---
+pull_request_rules:
+  - actions:
+      merge:
+        method: rebase
+        rebase_fallback: null
+        strict: true
+    conditions:
+      - label=ready-to-merge
+      - '#approved-reviews-by>=1'
+      - status-success~=Test python
+      - status-success~=Build & publish package to pypi
+      - status-success~=Build docs
+      - status-success~=docs/readthedocs.org
+    name: default

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -26,8 +26,8 @@
 DOCS_DIR      := docs
 TOP_DIR       := ..
 BUILD_JSON    := build.json
-BUILD_REPO    := https://github.com/crate/crate-docs-build.git
-CLONE_DIR     := .crate-docs-build
+BUILD_REPO    := https://github.com/crate/crate-docs.git
+CLONE_DIR     := .crate-docs
 SRC_DIR       := $(CLONE_DIR)/src
 SELF_SRC      := $(TOP_DIR)/src
 SELF_MAKEFILE := $(SELF_SRC)/rules.mk

--- a/docs/build.json
+++ b/docs/build.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
   "label": "docs build",
-  "message": "0.3.2"
+  "message": "0.4.0"
 }


### PR DESCRIPTION
the primary purpose of this is to upgrade to the new docs build system

I noticed that the Travis config was gone but I can't find the commit that removed it. hmm

we currently use Travis for testing the docs. I've added back in a Travis config that only tests the docs

I've also gone ahead and added the Mergify config we're using on other docs projects. but I have slightly modified it to account for the GitHub Actions you have set up for testing the code

lmk what you think!! :)