### PR TITLE
Make ctrl-d only quit program on empty command line

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,8 +8,9 @@ Unreleased
 Changes
 =======
 
-- Upgraded the CrateDB python driver to 0.26.0 in order to enable TCP keepalive
+- Upgrade the CrateDB python driver to 0.26.0 in order to enable TCP keepalive
   on the socket level.
+- Make ctrl-d only quit program on empty command line, like any other shell
 
 2020/09/21 0.26.0
 =================

--- a/crate/crash/keybinding.py
+++ b/crate/crash/keybinding.py
@@ -38,6 +38,10 @@ def mk_filter(buf, fn):
     return call_fn
 
 
+def _is_empty_line(doc):
+    return not doc.text
+
+
 def _is_start_of_multiline(doc):
     return doc.text and not doc.get_word_before_cursor()
 
@@ -55,7 +59,7 @@ def bind_keys(buf, key_bindings):
 
     handle = key_bindings.add
 
-    @handle('c-d')
+    @handle('c-d', filter=mk_filter(buf, _is_empty_line))
     def exit_(event):
         event.app.exit(exception=EOFError, style='class:exiting')
 


### PR DESCRIPTION
Hi there,

thanks a bunch for conceiving and maintaining `crash`. 

When starting to work with the program recently, it regularly occurred to me that I unintentionally quit the program by pressing CTRL-D. This improvement only quits the program when pressing CTRL-D on an **empty** command line. Otherwise, CTRL-D will act as the delete key, as we are used to it when working within other shells.

With kind regards,
Andreas.

P.S.: Unfortunately, I haven't been able to invoke the test suite. I hope this change doesn't break anything related to that. Let me know if this update needs any further adjustments.
