### PR TITLE
Correction: Use HTTPS instead of HTTP for links

### DIFF
--- a/docs/run.rst
+++ b/docs/run.rst
@@ -238,7 +238,7 @@ In both instances:
   cluster
 
 .. _command-line: https://en.wikipedia.org/wiki/Command-line_interface
-.. _jq: http://stedolan.github.io/jq/
+.. _jq: https://stedolan.github.io/jq/
 .. _pipe: https://www.wikiwand.com/en/Pipeline_(Unix)
 .. _piping: https://www.wikiwand.com/en/Pipeline_(Unix)
 .. _redirecting: https://tldp.org/LDP/abs/html/io-redirection.html


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

see crate/tech-writing-domain#316
