### PR TITLE
Improve CI tests on GHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@master

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,6 +3,7 @@ import re
 import ssl
 import sys
 import tempfile
+import unittest
 from doctest import testfile
 from io import StringIO, TextIOWrapper
 from unittest import TestCase
@@ -24,6 +25,9 @@ from crate.crash.commands import Command
 from crate.crash.outputs import _val_len as val_len
 from crate.crash.printer import ColorPrinter
 from crate.testing.layer import CrateLayer
+
+if sys.platform != "linux":
+    raise unittest.SkipTest("Integration tests only supported on Linux")
 
 crate_http_port = 44209
 crate_transport_port = 44309


### PR DESCRIPTION
Hi there,

this patch slightly adjusts the CI/GHA configuration.

- Invoke integration tests on Linux only
  I found a quick way to disabled integration tests on all other operating systems than Linux. When we have solved #343, we will be able to run them on all operating systems.
- Add macOS, Windows and Python 3.9 to test matrix.

With kind regards,
Andreas.
