### PR TITLE
Fix create_tag script

### DIFF
--- a/devtools/create_tag.sh
+++ b/devtools/create_tag.sh
@@ -48,7 +48,7 @@ fi
 
 # check if tag to create has already been created
 SCRIPT_DIR=`dirname $0`
-VERSION=`$SCRIPT_DIR/../bin/py setup.py --version`
+VERSION=`python setup.py --version`
 EXISTS=`git tag | grep $VERSION`
 
 if [ "$VERSION" == "$EXISTS" ]


### PR DESCRIPTION
It looks like `create_tag.sh` depended on a local buildout installation beforehand. This improvement by @mfussenegger already appears to get things more straightforward on this matter.

Hereby, I am handing this in as a pull request.