### PR TITLE
Fix warning from last publishing operation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
     author_email='office@crate.io',
     description='CrateDB Shell',
     long_description=long_description,
+    long_description_content_type='text/x-rst',
     platforms=['any'],
     license='Apache License 2.0',
     keywords='crate db data client shell',


### PR DESCRIPTION
While everything went through on the last publishing operation for version 0.27.0, this fixes a warning which appeared at the end of the build process.