### PR TITLE
CrateDB bundles the JRE with recent releases so we don't need it on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,11 +18,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Set up Java
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
This removes installing Java on CI/GHA. Because CrateDB now bundles the JRE, this should not do any harm but will save some cycles instead.