### PR TITLE
Standardize PyPI auth token name on CI and improve release documentation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,4 +57,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
-          password: ${{ secrets.pypi_password }}
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,9 +52,9 @@ jobs:
           python setup.py sdist bdist_wheel
           twine check dist/*.tar.gz
 
-      - name: Publish package
+      - name: Publish package to PyPI
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,7 @@ Unreleased
 =================
 
 - Added support for Python 3.10.
+
 - Fixed tabular output with rows containing only whitespace or other
   non-printable characters by upgrading to upstream ``tabulate`` package.
 

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -125,7 +125,12 @@ To create a new release, you must:
 - Create a tag by running ``./devtools/create_tag.sh``
 
 - ``create_tag.sh`` pushes a new tag to Github, that triggers a Github action
-  which releases the new version to PyPi.
+  which releases the new version to PyPI.
+
+- Designate the new release on GitHub at https://github.com/crate/crash/releases
+
+- Run the ``crash_standalone`` job on Jenkins in order to produce and publish
+  a self-contained executable to https://cdn.crate.io/downloads/releases/
 
 - Archive docs for old releases (see below)
 


### PR DESCRIPTION
Releasing 0.28.0 had some troubles because the PyPI token was named differently in the project's settings vs. the CI job configuration. This patch adjusts it to use the standard name `PYPI_API_TOKEN`, as outlined within the corresponding documentation [^1].

Afterwards, two other commits have been added:
- b057d2d adjusts the version of the GHA -> PyPI publish action
- 84fb56c6fe improves the release documentation

[^1]: https://github.com/pypa/gh-action-pypi-publish