### PR TITLE
Dropped support for Python < 3.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2019]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         cratedb-version: ['3.3.6', '4.7.1']
     env:
       OS: ${{ matrix.os }}

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for crash
 Unreleased
 ==========
 
+- Dropped support for Python < 3.7.
+
 2022/04/13 0.28.0
 =================
 

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ Standalone
 ----------
 
 Crash is also available as a standalone executable that includes all the
-necessary dependencies, and can be run as long as Python (>= 3.5) is available
+necessary dependencies, and can be run as long as Python (>= 3.7) is available
 on your system.
 
 First, download the executable file::

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
         ],
         argcompletion=['argcomplete']
     ),
-    python_requires='>=3.5',
+    python_requires='>=3.7',
     install_requires=requirements,
     package_data={'': ['*.txt']},
     classifiers=[
@@ -94,8 +94,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy3, py35, py36, py37, py38, py39, py310
+envlist = pypy3, py37, py38, py39, py310
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

As Python 3.5 and 3.6 don't receive updates anymore, I think we can drop their support.
## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
