### PR TITLE
Chore: CI maintenance

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,9 +15,9 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - name: Build docs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2019]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
         cratedb-version: ['4.8.4', '5.1.1']
     env:
       OS: ${{ matrix.os }}
@@ -22,6 +22,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          architecture: x64
+          cache: 'pip'
+          cache-dependency-path: 'setup.py'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-2019]
+        os: ['ubuntu-20.04', 'macos-latest', 'windows-2019']
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
         cratedb-version: ['4.8.4', '5.1.1']
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,9 +17,9 @@ jobs:
       CRATEDB_VERSION: ${{ matrix.cratedb-version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -39,10 +39,10 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2019]
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
-        cratedb-version: ['3.3.6', '4.7.1']
+        cratedb-version: ['4.8.4', '5.1.1']
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Database'

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -27,7 +27,7 @@ from crate.testing.layer import CrateLayer
 if sys.platform != "linux":
     raise SkipTest("Integration tests only supported on Linux")
 
-crate_version = os.getenv("CRATEDB_VERSION", "4.7.1")
+crate_version = os.getenv("CRATEDB_VERSION", "5.1.1")
 crate_http_port = 44209
 crate_transport_port = 44309
 crate_settings = {


### PR DESCRIPTION
- Update GHA recipe versions.
- Update CrateDB versions, use 4.8.4 and 5.1.1.
- Add support for Python 3.11.
