### PR TITLE
Dependencies: Update to tabulate 0.9.0, and drop support for Python 3.5 and 3.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-20.04', 'macos-latest', 'windows-2019']
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         cratedb-version: ['4.8.4', '5.2.0']
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-20.04', 'macos-latest', 'windows-2019']
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         cratedb-version: ['4.8.4', '5.2.0']
     env:
       OS: ${{ matrix.os }}

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for crash
 Unreleased
 ==========
 
+- Add support for Python 3.11, and drop support for Python 3.5 and 3.6.
+
 2022/04/13 0.28.0
 =================
 

--- a/README.rst
+++ b/README.rst
@@ -59,10 +59,6 @@ To update, run::
 
     pip install -U crash
 
-If you are not using Python version 3.5 or above, recent version of `pip`_ will
-install an earlier version of Crash. This is because newer versions of this
-package are not compatible with Python 2.7 or 3.4 and below.
-
 Standalone
 ----------
 

--- a/crate/crash/tabulate.py
+++ b/crate/crash/tabulate.py
@@ -1,4 +1,3 @@
-import tabulate
 from tabulate import DataRow, Line as TabulateLine, TableFormat, _strip_ansi
 
 crate_fmt = TableFormat(lineabove=TabulateLine("+", "-", "+", "+"),
@@ -52,6 +51,7 @@ def _format(val, valtype, floatfmt, intfmt="", missingval="", has_invisible=True
 
 
 def monkeypatch():
+    import tabulate
 
     # Register custom table format.
     tabulate._table_formats["cratedb"] = crate_fmt

--- a/crate/crash/tabulate.py
+++ b/crate/crash/tabulate.py
@@ -1,12 +1,5 @@
 import tabulate
-from tabulate import (
-    DataRow,
-    Line as TabulateLine,
-    TableFormat,
-    _binary_type,
-    _strip_invisible,
-    _text_type,
-)
+from tabulate import DataRow, Line as TabulateLine, TableFormat, _strip_ansi
 
 crate_fmt = TableFormat(lineabove=TabulateLine("+", "-", "+", "+"),
                         linebelowheader=TabulateLine("+", "-", "+", "+"),
@@ -18,7 +11,7 @@ crate_fmt = TableFormat(lineabove=TabulateLine("+", "-", "+", "+"),
                         with_header_hide=None)
 
 
-def _format(val, valtype, floatfmt, missingval="", has_invisible=True):
+def _format(val, valtype, floatfmt, intfmt="", missingval="", has_invisible=True):
     """Format a value according to its type.
 
     Unicode is supported:
@@ -33,19 +26,19 @@ def _format(val, valtype, floatfmt, missingval="", has_invisible=True):
     if val is None:
         return missingval
 
-    if valtype in [int, _text_type]:
+    if valtype is (int, str):
         return "{0}".format(val)
-    elif valtype is _binary_type:
+    elif valtype is bytes:
         try:
-            return _text_type(val, "ascii")
+            return str(val, "ascii")
         except TypeError:
-            return _text_type(val)
+            return str(val)
     elif valtype is float:
         is_a_colored_number = has_invisible and isinstance(
-            val, (_text_type, _binary_type)
+            val, (str, bytes)
         )
         if is_a_colored_number:
-            raw_val = _strip_invisible(val)
+            raw_val = _strip_ansi(val)
             formatted_val = format(float(raw_val), floatfmt)
             return val.replace(raw_val, formatted_val)
         # PATCH: Preserve string formatting even for numeric looking values.

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ requirements = [
     'crate>=0.26.0',
     'appdirs>=1.2,<2.0',
     'prompt-toolkit>=2.0,<3.0',
-    'tabulate>=0.8,<0.9',
+    'tabulate>=0.9,<0.10',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
         ],
         argcompletion=['argcomplete']
     ),
-    python_requires='>=3.5',
+    python_requires='>=3.7',
     install_requires=requirements,
     package_data={'': ['*.txt']},
     classifiers=[
@@ -94,8 +94,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
In the spirit of modernizing the package dependencies, in order to allow the program to co-exist within Python environments needing a more recent version of the `tabulate` package, this patch uses the gist of https://github.com/astanin/python-tabulate/pull/161 to accomodate the update.

~~P.S.: While that patch to `tabulate` officially drops support for Python 3.6, the `crash` test suite still succeeds, so why not keep it for a while.~~

Following that patch to `tabulate`, this patch implicitly drops support for Python 3.6 here. Nevertheless, we will state it within the changelog explicitly.
