### PR TITLE
Chore: Fix Mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -22,4 +22,3 @@ pull_request_rules:
       queue:
         method: rebase
         name: default
-        rebase_fallback: none


### PR DESCRIPTION
The Mergify configuration used the deprecated `rebase_fallback` mode of the queue and/or merge action.

- https://docs.mergify.com/actions/queue/#queue-action
- https://github.com/crate/crash/pull/376/checks
