### PR TITLE
Dependencies: Switch from `appdirs` to `platformdirs`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,8 +63,7 @@ Standalone
 ----------
 
 Crash is also available as a standalone executable that includes all the
-necessary dependencies, and can be run as long as Python (>= 3.5) is available
-on your system.
+necessary dependencies.
 
 First, download the executable file::
 

--- a/crate/crash/command.py
+++ b/crate/crash/command.py
@@ -35,7 +35,7 @@ from getpass import getpass
 from operator import itemgetter
 
 import urllib3
-from appdirs import user_config_dir, user_data_dir
+from platformdirs import user_config_dir, user_data_dir
 from urllib3.exceptions import LocationParseError
 
 from crate.client import connect

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ requirements = [
     'colorama<1',
     'Pygments>=2.4,<3',
     'crate>=0.26.0',
-    'appdirs>=1.2,<2.0',
+    'platformdirs<3',
     'prompt-toolkit>=2.0,<3.0',
     'tabulate>=0.9,<0.10',
 ]


### PR DESCRIPTION
The `appdirs` library stopped being maintained, and `platformdirs`, a friendly fork, is the official successor library.

- https://pypi.org/project/appdirs/
- https://pypi.org/project/platformdirs/
