### PR TITLE
Fix compatibility issue with `crate-0.30.0` when comparing versions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,9 @@ Unreleased
 
 - Add support for Python 3.11, and drop support for Python 3.5 and 3.6.
 
+- Fix compatibility issue with ``crate-0.30.0`` in the area of comparing
+  server version numbers.
+
 2022/04/13 0.28.0
 =================
 

--- a/crate/crash/command.py
+++ b/crate/crash/command.py
@@ -30,7 +30,6 @@ import re
 import sys
 from argparse import ArgumentParser, ArgumentTypeError
 from collections import namedtuple
-from distutils.version import StrictVersion
 from getpass import getpass
 from operator import itemgetter
 
@@ -39,6 +38,7 @@ from platformdirs import user_config_dir, user_data_dir
 from urllib3.exceptions import LocationParseError
 
 from crate.client import connect
+from crate.client._pep440 import Version
 from crate.client.exceptions import ConnectionError, ProgrammingError
 
 from ..crash import __version__ as crash_version
@@ -67,8 +67,8 @@ Result = namedtuple('Result', ['cols',
 
 ConnectionMeta = namedtuple('ConnectionMeta', ['user', 'schema', 'cluster'])
 
-TABLE_SCHEMA_MIN_VERSION = StrictVersion("0.57.0")
-TABLE_TYPE_MIN_VERSION = StrictVersion("2.0.0")
+TABLE_SCHEMA_MIN_VERSION = Version("0.57.0")
+TABLE_TYPE_MIN_VERSION = Version("2.0.0")
 
 
 def parse_config_path(args=sys.argv):
@@ -329,7 +329,7 @@ class CrateShell:
 
     def is_conn_available(self):
         return self.connection and \
-            self.connection.lowest_server_version != StrictVersion("0.0.0")
+            self.connection.lowest_server_version != Version("0.0.0")
 
     def _connect(self, servers):
         self.last_connected_servers = servers
@@ -398,7 +398,7 @@ class CrateShell:
 
     def _fetch_session_info(self):
         if self.is_conn_available() \
-                and self.connection.lowest_server_version >= StrictVersion("2.0"):
+                and self.connection.lowest_server_version >= Version("2.0"):
 
             try:
                 self.cursor.execute('SELECT current_user, current_schema, name FROM sys.cluster')

--- a/crate/crash/commands.py
+++ b/crate/crash/commands.py
@@ -20,7 +20,8 @@
 import functools
 import os
 from collections import OrderedDict
-from distutils.version import StrictVersion
+
+from crate.client._pep440 import Version
 
 
 class Command(object):
@@ -176,7 +177,7 @@ class NodeCheckCommand(CheckBaseCommand):
     check_name = None
 
     def __call__(self, cmd, **kwargs):
-        if cmd.connection.lowest_server_version >= StrictVersion("0.56.0"):
+        if cmd.connection.lowest_server_version >= Version("0.56.0"):
             startup = kwargs.get('startup', False)
             stmt = startup and self.STARTUP_STMT or self.DEFAULT_STMT
             self.check_name = startup and "TYPES OF NODE CHECK" or "NODE CHECK"
@@ -199,7 +200,7 @@ class ClusterCheckCommand(CheckBaseCommand):
     check_name = "CLUSTER CHECK"
 
     def __call__(self, cmd, **kwargs):
-        if cmd.connection.lowest_server_version >= StrictVersion("0.52.0"):
+        if cmd.connection.lowest_server_version >= Version("0.52.0"):
             self.execute(cmd, self.STMT)
         else:
             tmpl = 'Crate {version} does not support the cluster "check" command.'

--- a/crate/crash/sysinfo.py
+++ b/crate/crash/sysinfo.py
@@ -22,10 +22,11 @@
 
 
 from collections import namedtuple
-from distutils.version import StrictVersion
+
+from crate.client._pep440 import Version
 
 Result = namedtuple('Result', ['rows', 'cols'])
-SYSINFO_MIN_VERSION = StrictVersion("0.54.0")
+SYSINFO_MIN_VERSION = Version("0.54.0")
 
 
 class SysInfoCommand:

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from setuptools import setup
 requirements = [
     'colorama<1',
     'Pygments>=2.4,<3',
-    'crate>=0.26.0',
+    'crate>=0.30.0',
     'platformdirs<3',
     'prompt-toolkit>=3.0,<4',
     'tabulate>=0.9,<0.10',

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # vim: set fileencodings=utf-8
 
-from distutils.version import StrictVersion
 from unittest import TestCase
 
+from crate.client._pep440 import Version
 from crate.crash.command import (
     Result,
     get_information_schema_query,
@@ -115,7 +115,7 @@ class CommandUtilsTest(TestCase):
 class TestGetInformationSchemaQuery(TestCase):
 
     def test_low_version(self):
-        lowest_server_version = StrictVersion("0.56.4")
+        lowest_server_version = Version("0.56.4")
         query = get_information_schema_query(lowest_server_version)
         self.assertEqual(""" select count(distinct(table_name))
                 as number_of_tables
@@ -124,7 +124,7 @@ class TestGetInformationSchemaQuery(TestCase):
             not in ('information_schema', 'sys', 'pg_catalog') """, query)
 
     def test_high_version(self):
-        lowest_server_version = StrictVersion("1.0.4")
+        lowest_server_version = Version("1.0.4")
         query = get_information_schema_query(lowest_server_version)
         self.assertEqual(""" select count(distinct(table_name))
                 as number_of_tables

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -22,10 +22,10 @@
 import os
 import shutil
 import tempfile
-from distutils.version import StrictVersion
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+from crate.client._pep440 import Version
 from crate.crash.command import CrateShell
 from crate.crash.commands import (
     CheckCommand,
@@ -131,21 +131,21 @@ class ShowTablesCommandTest(TestCase):
     def test_post_2_0(self):
         cmd = CrateShell()
         cmd._exec_and_print = MagicMock()
-        cmd.connection.lowest_server_version = StrictVersion("2.0.0")
+        cmd.connection.lowest_server_version = Version("2.0.0")
         cmd._show_tables()
         cmd._exec_and_print.assert_called_with("SELECT format('%s.%s', table_schema, table_name) AS name FROM information_schema.tables WHERE table_schema NOT IN ('sys','information_schema', 'pg_catalog') AND table_type = 'BASE TABLE' ORDER BY 1")
 
     def test_post_0_57(self):
         cmd = CrateShell()
         cmd._exec_and_print = MagicMock()
-        cmd.connection.lowest_server_version = StrictVersion("0.57.0")
+        cmd.connection.lowest_server_version = Version("0.57.0")
         cmd._show_tables()
         cmd._exec_and_print.assert_called_with("SELECT format('%s.%s', table_schema, table_name) AS name FROM information_schema.tables WHERE table_schema NOT IN ('sys','information_schema', 'pg_catalog') ORDER BY 1")
 
     def test_pre_0_57(self):
         cmd = CrateShell()
         cmd._exec_and_print = MagicMock()
-        cmd.connection.lowest_server_version = StrictVersion("0.56.4")
+        cmd.connection.lowest_server_version = Version("0.56.4")
         cmd._show_tables()
         cmd._exec_and_print.assert_called_with("SELECT format('%s.%s', schema_name, table_name) AS name FROM information_schema.tables WHERE schema_name NOT IN ('sys','information_schema', 'pg_catalog') ORDER BY 1")
 
@@ -163,14 +163,14 @@ class ChecksCommandTest(TestCase):
         cmd._exec.return_value = True
         cmd.cursor.fetchall.return_value = rows
         cmd.cursor.description = cols
-        cmd.connection.lowest_server_version = StrictVersion("0.56.4")
+        cmd.connection.lowest_server_version = Version("0.56.4")
 
         NodeCheckCommand()(cmd)
         cmd.pprint.assert_called_with(rows, [c[0] for c in cols])
 
     @patch('crate.crash.command.CrateShell')
     def test_node_check_for_not_supported_version(self, cmd):
-        cmd.connection.lowest_server_version = StrictVersion("0.52.3")
+        cmd.connection.lowest_server_version = Version("0.52.3")
         NodeCheckCommand()(cmd)
         excepted = 'Crate 0.52.3 does not support the "\check nodes" command.'
         cmd.logger.warn.assert_called_with(excepted)
@@ -186,14 +186,14 @@ class ChecksCommandTest(TestCase):
         cmd._exec.return_value = True
         cmd.cursor.fetchall.return_value = rows
         cmd.cursor.description = cols
-        cmd.connection.lowest_server_version = StrictVersion("0.53.1")
+        cmd.connection.lowest_server_version = Version("0.53.1")
 
         ClusterCheckCommand()(cmd)
         cmd.pprint.assert_called_with(rows, [c[0] for c in cols])
 
     @patch('crate.crash.command.CrateShell')
     def test_cluster_check_for_not_supported_version(self, cmd):
-        cmd.connection.lowest_server_version = StrictVersion("0.49.4")
+        cmd.connection.lowest_server_version = Version("0.49.4")
         ClusterCheckCommand()(cmd)
         excepted = 'Crate 0.49.4 does not support the cluster "check" command.'
         cmd.logger.warn.assert_called_with(excepted)
@@ -203,7 +203,7 @@ class ChecksCommandTest(TestCase):
         command = CheckCommand()
         cmd._exec.return_value = True
         cmd.cursor.fetchall.return_value = []
-        cmd.connection.lowest_server_version = StrictVersion("0.56.1")
+        cmd.connection.lowest_server_version = Version("0.56.1")
 
         command(cmd, 'cluster')
         cmd.logger.info.assert_called_with('CLUSTER CHECK OK')
@@ -213,7 +213,7 @@ class ChecksCommandTest(TestCase):
         command = CheckCommand()
         cmd._exec.return_value = True
         cmd.cursor.fetchall.return_value = []
-        cmd.connection.lowest_server_version = StrictVersion("0.56.1")
+        cmd.connection.lowest_server_version = Version("0.56.1")
 
         command(cmd, 'nodes')
         cmd.logger.info.assert_called_with('NODE CHECK OK')

--- a/tests/test_sysinfo.py
+++ b/tests/test_sysinfo.py
@@ -21,14 +21,14 @@
 # software solely pursuant to the terms of the relevant commercial agreement.
 
 
-from distutils.version import StrictVersion
 from unittest import TestCase
 from unittest.mock import PropertyMock, patch
 
+from crate.client._pep440 import Version
 from crate.crash.command import CrateShell
 from crate.crash.sysinfo import Result as Res, SysInfoCommand
 
-CRATE_VERSION = StrictVersion("0.55.2")
+CRATE_VERSION = Version("0.55.2")
 assert CrateShell, "Used for patch"
 
 


### PR DESCRIPTION
This patch fixes a compatibility issue with the recently released `crate-0.30.0` package, reported by @proddata. Thanks! It is related to: 

- https://github.com/crate/crate-python/pull/513

```python
File "/var/lib/jenkins/workspace/CrateDB/crate_test_hourly_master/blackbox/.venv/lib/python3.9/site-packages/crate/crash/command.py", line 401, in _fetch_session_info
    and self.connection.lowest_server_version >= StrictVersion("2.0"):
TypeError: '>=' not supported between instances of 'Version' and 'StrictVersion'
```
