### PR TITLE
CI: Reduce resource usage and speed up testing cycle

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,9 +12,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-latest']
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         cratedb-version: ['4.8.4', '5.2.2']
+        include:
+          - os: 'macos-latest'
+            python-version: '3.11'
+            cratedb-version: '5.2.2'
+          - os: 'windows-latest'
+            python-version: '3.11'
+            cratedb-version: '5.2.2'
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -123,7 +123,7 @@ To create a new release, you must:
 
 - Create a tag by running ``./devtools/create_tag.sh``.
   It will push a new tag to GitHub, which in turn will trigger a GitHub action
-  that releases the new version to PyPI.
+  that releases the new version to PyPI at https://pypi.org/project/crash/
 
 - Designate the new release on GitHub at https://github.com/crate/crash/releases
 


### PR DESCRIPTION
I found the CI to be rather heavy, it takes ages to complete. This patch makes it a bit more lightweight, following practises we already applied to other repositories successfully [1], without ending up missing any incompatibility issues so far.

- ~~Take CrateDB 4.8 release out of the test matrix.~~
- Run only a single test matrix slot for macOS and Windows, using the most recent stable Python 3.11. I think it is acceptable.

#### References
- [1] https://github.com/earthobservations/wetterdienst/pull/817
