### PR TITLE
Add support for multi-line SQL and commands.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,8 @@ Unreleased
 ==========
 
 - Fix inconsistent spacing around printed runtime. Thank you, @hammerhead.
+- Add support for multi-line input of commands and SQL statements for both
+  copy-pasting inside the crash shell and input pipes into crash.
 
 2023/02/16 0.29.0
 =================

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ requirements = [
     'platformdirs<4',
     'prompt-toolkit>=3.0,<4',
     'tabulate>=0.9,<0.10',
+    'sqlparse>=0.4.4,<0.5.0'
 ]
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -13,8 +13,8 @@ from crate.client.exceptions import ProgrammingError
 from crate.crash.command import (
     CrateShell,
     _create_shell,
+    get_lines_from_stdin,
     get_parser,
-    get_stdin,
     host_and_port,
     main,
     noargs_command,
@@ -315,7 +315,7 @@ class CommandTest(TestCase):
 
         Newlines must be replaced with whitespaces
         """
-        stmt = ''.join(list(get_stdin())).replace('\n', ' ')
+        stmt = ''.join(list(get_lines_from_stdin())).replace('\n', ' ')
         expected = ("create table test( d string ) "
                     "clustered into 2 shards "
                     "with (number_of_replicas=0)")
@@ -334,7 +334,7 @@ class CommandTest(TestCase):
 
         Newlines must be replaced with whitespaces
         """
-        stmt = ''.join(list(get_stdin())).replace('\n', ' ')
+        stmt = ''.join(list(get_lines_from_stdin())).replace('\n', ' ')
         expected = ("create table test( d string ) "
                     "clustered into 2 shards "
                     "with (number_of_replicas=0);")


### PR DESCRIPTION
Fixes #349 

As discussed in the issue, I replaced the custom SQL parsing with `sqlparse` library as it seems to be more reliable. Also, I saw there is an inconsistency between `process` and `process_iterable` as one was able to execute commands and the other did not, so I refactored how they work a little.

Now, multi-line input can contain single-line SQL, multi-line SQL and commands, all together.