### PR TITLE
CI: Run software tests on pull requests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,10 +1,10 @@
 name: "CodeQL"
 
 on:
+  pull_request: ~
   push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
+    branches:
+      - master
   schedule:
     - cron: "50 19 * * 6"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 ---
 name: test
-on: push
+on:
+  pull_request: ~
+  push:
+    branches:
+      - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
GH-386 revealed that software tests apparently are not invoked on pull requests. This patch aims to improve that detail.