### PR TITLE
Fix inconsistent spacing around printed runtime

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 ---
 name: test
-on: push
+on:
+  pull_request: ~
+  push:
+    branches:
+      - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for crash
 Unreleased
 ==========
 
+- Fix inconsistent spacing around printed runtime. Thank you, @hammerhead.
+
 2023/02/16 0.29.0
 =================
 

--- a/crate/crash/command.py
+++ b/crate/crash/command.py
@@ -488,7 +488,7 @@ class CrateShell:
             self.pprint(cur.fetchall(), [c[0] for c in cur.description])
             tmpl = '{command} {rowcount} row{s} in set{duration}'
         else:
-            tmpl = '{command} OK, {rowcount} row{s} affected {duration}'
+            tmpl = '{command} OK, {rowcount} row{s} affected{duration}'
         self.logger.info(tmpl.format(**print_vars))
         return True
 


### PR DESCRIPTION
This patch aims to fix GH-384 reported by @hammerhead.

> For some types of statements, there have been two spaces between the message (1 row affected) and the runtime (0.172 sec) instead of one.
