### PR TITLE
CI: Fix staging releases through GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,13 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/" # Location of package manifests
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,28 +48,3 @@ jobs:
 
       - name: Lint & test
         run: ./devtools/ci.sh 
-
-  pypi:
-    name: Build & publish package to pypi
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.11
-
-      - name: Build package
-        run: |
-          python -m pip install twine wheel
-          python setup.py sdist bdist_wheel
-          twine check dist/*.tar.gz
-
-      - name: Publish package to PyPI
-        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+---
+name: release
+
+on: push
+
+jobs:
+  pypi:
+    name: Build & publish package to PyPI
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.ref, 'refs/tags')
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: 'setup.py'
+
+      - name: Build package
+        run: |
+          python -m pip install build twine wheel
+          python -m build
+          twine check dist/{*.tar.gz,*.whl}
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## About

The GHA recipe did not manage to publish a release to PyPI. Because
everything works on the `crate` driver package, let's just use the same
recipe here without further ado.


## Details

The GHA recipe did not trigger the »Publish package to PyPI« step.
I did not investigate why.

![image](https://github.com/crate/crash/assets/453543/ccaa772f-fa4d-41da-bd1f-7fd6e4e63b19)

-- https://github.com/crate/crash/actions/runs/5480636342/jobs/9984067119
