### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           architecture: x64
           cache: 'pip'
           cache-dependency-path: 'setup.py'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.12
       - name: Build docs
         run: |
           cd docs && make check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,14 +25,14 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         cratedb-version: ['4.8.4', '5.3.2']
         include:
           - os: 'macos-latest'
-            python-version: '3.11'
+            python-version: '3.12'
             cratedb-version: '5.3.2'
           - os: 'windows-latest'
-            python-version: '3.11'
+            python-version: '3.12'
             cratedb-version: '5.3.2'
     env:
       OS: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: 'setup.py'
 

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Database'


### PR DESCRIPTION
## About

After https://github.com/jazzband/geojson/pull/222 has been released with geojson 3.1.0, verify that everything works well on Python 3.12, and add it to the package's metadata. Also use it right away on other auxiliary CI tasks.
