### PR TITLE
CI: Use CrateDB 5.4.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,14 +26,14 @@ jobs:
       matrix:
         os: ['ubuntu-latest']
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
-        cratedb-version: ['4.8.4', '5.3.2']
+        cratedb-version: ['4.8.4', '5.4.5']
         include:
           - os: 'macos-latest'
             python-version: '3.12'
-            cratedb-version: '5.3.2'
+            cratedb-version: '5.4.5'
           - os: 'windows-latest'
             python-version: '3.12'
-            cratedb-version: '5.3.2'
+            cratedb-version: '5.4.5'
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}


### PR DESCRIPTION
## About

On CI, use a more recent version of CrateDB.