### PR TITLE
Remove QA support for Python 3.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         cratedb-version: ['4.8.4', '5.4.5']
         include:
           - os: 'macos-latest'

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,7 @@ Changes for crash
 Unreleased
 ==========
 
+- Remove QA support for Python 3.7. Thanks, @pilosus.
 
 2023/07/06 0.30.0
 =================

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
## About

As suggested by @pilosus at GH-408, this patch drops official support for Python 3.7.