### PR TITLE
CLI: Display output format choices within `crash --help`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for crash
 Unreleased
 ==========
 
+- CLI: Added possible output format choices for ``--format`` argument to
+  ``crash --help``. Thanks, @mfussenegger.
 
 2023/07/06 0.30.0
 =================

--- a/crate/crash/command.py
+++ b/crate/crash/command.py
@@ -155,7 +155,8 @@ def get_parser(output_formats=[], conf=None):
     parser.add_argument('--format', type=str,
                         default=_conf_or_default('format', 'tabular'),
                         choices=output_formats, metavar='FORMAT',
-                        help='the output FORMAT of the SQL response')
+                        help=f'the output FORMAT of the SQL response.\n'
+                             f'choose one of: {", ".join(output_formats)}')
     parser.add_argument('--version', action='store_true', default=False,
                         help='print the Crash version and exit')
 


### PR DESCRIPTION
## About

Display the list of available output format choices right away within `crash --help`, to improve guidance. Thank you for this suggestion, @mfussenegger, it will resolve GH-409.

## Screenshot

```
crash --help
```
[...]
```
  --format FORMAT       the output FORMAT of the SQL response. choose one of: tabular,
                        json, csv, raw, mixed, dynamic, json_row
```
