### PR TITLE
CI: Turn off failing fast on the test matrix slots

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
     name: Python ${{ matrix.python-version }}, CrateDB ${{ matrix.cratedb-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: ['ubuntu-latest']
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']


### PR DESCRIPTION
## About

This is meant to support GH-408, so that we can get successful outcomes on the Python >= 3.8 slots already.

It is intended to be a temporary change, for a better overview. It can be reverted to save resources on daily operations later.
