### PR TITLE
Add command-line argument `--timeout`, to configure network timeout values

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,10 @@ Changes for crash
 
 Unreleased
 ==========
-
+- Added command-line argument ``--timeout``, to configure network timeout
+  values in seconds. The default connect timeout is five seconds now,
+  the default read timeout is the default setting of the ``socket`` module,
+  which is "infinite" by default.
 
 2024/01/12 0.30.2
 =================

--- a/docs/run.rst
+++ b/docs/run.rst
@@ -57,6 +57,13 @@ The ``crash`` executable supports multiple command-line options:
 |                               | command will succeed if at least one         |
 |                               | connection is successful.                    |
 +-------------------------------+----------------------------------------------+
+| ``--timeout <TIMEOUT>``       | Configure network timeout in "<connect_sec>" |
+|                               | or "<connect_sec>,<read_sec>" format.        |
+|                               |                                              |
+|                               | The default value is "5,-1", configuring a   |
+|                               | connect timeout of five seconds with         |
+|                               | infinite read timeout.                       |
++-------------------------------+----------------------------------------------+
 | ``--history <FILENAME>``      | Use ``<FILENAME>`` as a history file.        |
 |                               |                                              |
 |                               | Defaults to the ``crash_history`` file in    |


### PR DESCRIPTION
## About

Coming from GH-370, this patch introduces the `--timeout` command-line argument to specify the (connect, read) timeout values. The default connect timeout is five seconds now, the default read timeout is infinite.

## Backlog
- Needs https://github.com/crate/crate-python/pull/603.
