### PR TITLE
Use `verlib2.Version` instead of `crate.client._pep440.Version`

### DIFF
--- a/crate/crash/command.py
+++ b/crate/crash/command.py
@@ -37,9 +37,9 @@ import sqlparse
 import urllib3
 from platformdirs import user_config_dir, user_data_dir
 from urllib3.exceptions import LocationParseError
+from verlib2 import Version
 
 from crate.client import connect
-from crate.client._pep440 import Version
 from crate.client.exceptions import ConnectionError, ProgrammingError
 
 from ..crash import __version__ as crash_version

--- a/crate/crash/commands.py
+++ b/crate/crash/commands.py
@@ -21,7 +21,7 @@ import functools
 import os
 from collections import OrderedDict
 
-from crate.client._pep440 import Version
+from verlib2 import Version
 
 
 class Command(object):

--- a/crate/crash/sysinfo.py
+++ b/crate/crash/sysinfo.py
@@ -23,7 +23,7 @@
 
 from collections import namedtuple
 
-from crate.client._pep440 import Version
+from verlib2 import Version
 
 Result = namedtuple('Result', ['rows', 'cols'])
 SYSINFO_MIN_VERSION = Version("0.54.0")

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ requirements = [
     'platformdirs<5',
     'prompt-toolkit>=3.0,<4',
     'tabulate>=0.9,<0.10',
-    'sqlparse>=0.4.4,<0.5.0'
+    'sqlparse>=0.4.4,<0.5.0',
+    'verlib2<0.3',
 ]
 
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -3,7 +3,8 @@
 
 from unittest import TestCase
 
-from crate.client._pep440 import Version
+from verlib2 import Version
+
 from crate.crash.command import (
     Result,
     get_information_schema_query,

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -26,7 +26,8 @@ import tempfile
 from unittest import SkipTest, TestCase
 from unittest.mock import MagicMock, call, patch
 
-from crate.client._pep440 import Version
+from verlib2 import Version
+
 from crate.crash.command import CrateShell
 from crate.crash.commands import (
     CheckCommand,

--- a/tests/test_sysinfo.py
+++ b/tests/test_sysinfo.py
@@ -24,7 +24,8 @@
 from unittest import TestCase
 from unittest.mock import PropertyMock, patch
 
-from crate.client._pep440 import Version
+from verlib2 import Version
+
 from crate.crash.command import CrateShell
 from crate.crash.sysinfo import Result as Res, SysInfoCommand
 


### PR DESCRIPTION
## About
Instead of vendoring `Version` from `packaging`, pull it in via shared library [`verlib2`](https://github.com/pyveci/verlib2).

## Problem
`crash` broke after releasing `crate==0.35.0`, so I've yanked it again.
```python
ModuleNotFoundError: No module named 'crate.client._pep440'
```
-- https://github.com/crate/crash/actions/runs/7562783871/job/20593938496?pr=421#step:5:29

## Blocked By
- https://github.com/crate/crate-python/pull/605
- https://github.com/crate/crate-python/pull/606
