### PR TITLE
better catch unauthorized errors with forced password prompt

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for crash
 Unreleased
 ==========
 
+- Better catch unauthorized errors when forcing a password prompt.
+
 2024/01/29 0.31.0
 =================
 

--- a/crate/crash/command.py
+++ b/crate/crash/command.py
@@ -580,9 +580,8 @@ def main():
                             args, password=password)
     except (ProgrammingError, LocationParseError) as e:
         msg = getattr(e, 'message', str(e))
-        if '401' in msg and not args.force_passwd_prompt:
-            if is_tty:
-                password = getpass()
+        if '401' in msg and not args.force_passwd_prompt and is_tty:
+            password = getpass()
             try:
                 cmd = _create_shell(crate_hosts, error_trace, output_writer,
                                     is_tty, args, password=password)
@@ -590,7 +589,8 @@ def main():
                 printer.warn(str(ex))
                 sys.exit(1)
         else:
-            raise e
+            printer.warn(str(e))
+            sys.exit(1)
     except Exception as e:
         printer.warn(str(e))
         sys.exit(1)


### PR DESCRIPTION
## About

Better catch unauthorized errors with forced password prompt instead of displaying stack trace, when using the `-W` option.

```
 % crash --hosts 'https://elite-krait.eks1.eu-west-1.aws.cratedb.net:4200' -U 'admin' -W
Password: 
401 Client Error: Unauthorized
```

Before, it was like:

<details>

```
Password:
Traceback (most recent call last):
  File "/path/to/.venv/bin/crash", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/path/to/.venv/lib/python3.11/site-packages/crate/crash/command.py", line 589, in main
    raise e
  File "/path/to/.venv/lib/python3.11/site-packages/crate/crash/command.py", line 575, in main
    cmd = _create_shell(crate_hosts, error_trace, output_writer, is_tty,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/.venv/lib/python3.11/site-packages/crate/crash/command.py", line 622, in _create_shell
    return CrateShell(crate_hosts,
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/.venv/lib/python3.11/site-packages/crate/crash/command.py", line 228, in __init__
    self._connect(crate_hosts)
  File "/path/to/.venv/lib/python3.11/site-packages/crate/crash/command.py", line 323, in _connect
    self.connection = connect(servers,
                      ^^^^^^^^^^^^^^^^
  File "/path/to/.venv/lib/python3.11/site-packages/crate/client/connection.py", line 152, in __init__
    self.lowest_server_version = self._lowest_server_version()
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/.venv/lib/python3.11/site-packages/crate/client/connection.py", line 196, in _lowest_server_version
    _, _, version = self.client.server_infos(server)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/.venv/lib/python3.11/site-packages/crate/client/http.py", line 461, in server_infos
    _raise_for_status(response)
  File "/path/to/.venv/lib/python3.11/site-packages/crate/client/http.py", line 199, in _raise_for_status
    return _raise_for_status_real(response)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/.venv/lib/python3.11/site-packages/crate/client/http.py", line 231, in _raise_for_status_real
    raise ProgrammingError(message)
crate.client.exceptions.ProgrammingError: 401 Client Error: Unauthorized
```
</details>

## References

- https://community.cratedb.com/t/issue-connecting-to-cratedb-cloud-cluster-from-local-machine/1707
