### PR TITLE
Chore: Rename `crate.io` to `cratedb.com`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -184,7 +184,7 @@ The source files for the documentation are licensed under the Apache License
 Version 2.0. These source files are used by the project maintainers to build
 online documentation for end-users:
 
-  <https://crate.io/docs/clients/crash/>
+  <https://cratedb.com/docs/clients/crash/>
 
 If you want to make contributions to the documentation, it may be necessary for
 you to build the documentation yourself by following the instructions in the

--- a/README.rst
+++ b/README.rst
@@ -96,9 +96,11 @@ Looking for more help? Check out our `support channels`_.
 
 .. _command-line interface: https://en.wikipedia.org/wiki/Command-line_interface
 .. _contribution docs: CONTRIBUTING.rst
-.. _Crate.io: https://crate.io/
+.. _Crate.io: https://cratedb.com/
+.. _CrateDB: https://github.com/crate/crate
+.. _CrateDB Cloud: https://console.cratedb.cloud
+.. _CrateDB shell documentation: https://cratedb.com/docs/crate/crash/
 .. _developer docs: DEVELOP.rst
 .. _PATH: https://en.wikipedia.org/wiki/PATH_(variable)
 .. _pip: https://pypi.python.org/pypi/pip
-.. _CrateDB shell documentation: https://crate.io/docs/crate/crash/
-.. _support channels: https://crate.io/support/
+.. _support channels: https://cratedb.com/support/

--- a/docs/appendices/compatibility.rst
+++ b/docs/appendices/compatibility.rst
@@ -67,9 +67,9 @@ Consult the following table for CrateDB compatibility notes:
 |                |                 | has no password is set.                   |
 +----------------+-----------------+-------------------------------------------+
 
-.. _array constructors: https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#data-types-array-literals
-.. _client library: https://crate.io/docs/crate/clients-tools/en/latest/
-.. _CrateDB REST endpoint: https://crate.io/docs/crate/reference/en/latest/interfaces/http.html
-.. _create your own users: https://crate.io/docs/crate/reference/en/latest/admin/user-management.html
-.. _object literals: https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#data-types-object-literals
+.. _array constructors: https://cratedb.com/docs/crate/reference/en/latest/general/ddl/data-types.html#data-types-array-literals
+.. _client library: https://cratedb.com/docs/crate/clients-tools/en/latest/
+.. _CrateDB REST endpoint: https://cratedb.com/docs/crate/reference/en/latest/interfaces/http.html
+.. _create your own users: https://cratedb.com/docs/crate/reference/en/latest/admin/user-management.html
+.. _object literals: https://cratedb.com/docs/crate/reference/en/latest/general/ddl/data-types.html#data-types-object-literals
 .. _pip: https://pypi.org/project/pip/

--- a/docs/appendices/formats.rst
+++ b/docs/appendices/formats.rst
@@ -161,6 +161,6 @@ Example::
     ---------------------------------------------------------------
 
 .. _comma separated values: https://en.wikipedia.org/wiki/Comma-separated_values
-.. _COPY FROM: https://crate.io/docs/crate/reference/en/latest/general/dml.html#import-and-export
+.. _COPY FROM: https://cratedb.com/docs/crate/reference/en/latest/general/dml.html#import-and-export
 .. _JSON: https://www.json.org/
-.. _the CrateDB Python client library: https://crate.io/docs/python/en/latest/
+.. _the CrateDB Python client library: https://cratedb.com/docs/python/en/latest/

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -140,13 +140,13 @@ You should see something like this:
 
    For more help, see :ref:`commands` or :ref:`formats`.
 
-.. _Command Line Arguments: https://crate.io/docs/projects/crash/en/stable/cli.html
+.. _Command Line Arguments: https://cratedb.com/docs/projects/crash/en/stable/cli.html
 .. _crate-python: https://pypi.python.org/pypi/crate/
-.. _CrateDB REST Endpoint: https://crate.io/docs/current/sql/rest.html
-.. _CrateDB: https://crate.io/products/cratedb/
+.. _CrateDB REST Endpoint: https://cratedb.com/docs/current/sql/rest.html
+.. _CrateDB: https://cratedb.com/products/cratedb/
 .. _PATH: https://en.wikipedia.org/wiki/PATH_(variable)
 .. _pip: https://pypi.org/project/pip/
 .. _PyPI overview: https://pypi.python.org/pypi/crash/
-.. _Running CrateDB: https://crate.io/docs/crate/reference/en/latest/run.html
+.. _Running CrateDB: https://cratedb.com/docs/crate/reference/en/latest/run.html
 .. _shell: https://en.wikipedia.org/wiki/Shell_(computing)
 .. _STDOUT: https://en.wikipedia.org/wiki/Standard_streams


### PR DESCRIPTION
What the title says.