### PR TITLE
Update to crate>=0.35.2

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for crash
 Unreleased
 ==========
 
+- Update to crate>=0.35.2. It is needed to accompany the recent
+  improvements about ``--timeout``.
+
 2024/02/02 0.31.1
 =================
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from setuptools import setup
 requirements = [
     'colorama<1',
     'Pygments>=2.4,<3',
-    'crate>=0.30.0',
+    'crate>=0.35.2',
     'platformdirs<5',
     'prompt-toolkit>=3.0,<4',
     'tabulate>=0.9,<0.10',


### PR DESCRIPTION
## About
It is needed to accompany the recent improvements about `--timeout`. Fixes `float() argument must be a string or a real number, not 'Timeout'`, when using a crate-python version which is not recent.

## References
- GH-428
