### PR TITLE
Fix status line display of the executed SQL command

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,8 @@ Changes for crash
 Unreleased
 ==========
 
-- Use Python Testcontainers for integration testing
+- Started using Python Testcontainers for integration testing
+- Fixed status line display of the executed SQL command
 
 2024/02/08 0.31.2
 =================

--- a/crate/crash/output.txt
+++ b/crate/crash/output.txt
@@ -109,3 +109,26 @@ Status messages show the first word only::
     | 1 | 2 |
     +---+---+
     SELECT 1 row in set (... sec)
+
+
+    cr> /* foo */ select
+    ... 1,2
+    ... from sys.cluster limit 1;
+    +---+---+
+    | 1 | 2 |
+    +---+---+
+    | 1 | 2 |
+    +---+---+
+    SELECT 1 row in set (... sec)
+
+
+    cr> -- foo
+    ... select
+    ... 1,2
+    ... from sys.cluster limit 1;
+    +---+---+
+    | 1 | 2 |
+    +---+---+
+    | 1 | 2 |
+    +---+---+
+    SELECT 1 row in set (... sec)

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -113,6 +113,11 @@ class CommandUtilsTest(TestCase):
         # statements with trailing or leading spaces/tabs/linebreaks
         self.assertEqual(stmt_type(' SELECT 1 ;'), 'SELECT')
         self.assertEqual(stmt_type('\nSELECT\n1\n;\n'), 'SELECT')
+        # statements with trailing or leading comments
+        self.assertEqual(stmt_type('/* foo */ SELECT 1;'), 'SELECT')
+        self.assertEqual(stmt_type('SELECT 1; /* foo */'), 'SELECT')
+        self.assertEqual(stmt_type('-- foo \n SELECT 1;'), 'SELECT')
+        self.assertEqual(stmt_type('SELECT 1; -- foo'), 'SELECT')
 
     def test_decode_timeout_success(self):
         self.assertEqual(_decode_timeout(None), None)

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,23 @@
+from unittest.mock import Mock
+
+from crate.client.cursor import Cursor
+
+
+def mocked_cursor(description, records, duration=0.1):
+    """
+    Provide a mocked `crate.client.cursor.Cursor` instance.
+    """
+    rowcount = len(records)
+    fake_cursor = Mock(name='fake_cursor', description=description, rowcount=rowcount, duration=duration)
+    fake_cursor.fetchall.return_value = records
+    FakeCursor = Mock(name='FakeCursor', spec=Cursor)
+    FakeCursor.return_value = fake_cursor
+    return FakeCursor
+
+
+def fake_cursor():
+    """
+    Provide an empty/minimal mocked cursor object,
+    that just works if you do not care about results.
+    """
+    return mocked_cursor(description=[('undef',)], records=[('undef', None)])


### PR DESCRIPTION
## Problem
When prefixing an SQL statement with an SQL comment (both per-line `--` and block `/* */`), crash mistreats that comment as an SQL command when printing its status line.

![image](https://github.com/crate/crash/assets/453543/659e4c54-bcb7-418b-beca-b1317f30a10b)

**Full Example:**
```sql
$ echo '/*foo*/ select 1' | crash
CONNECT OK
+---+
| 1 |
+---+
| 1 |
+---+
FOO 1 row in set (0.001 sec)
```

## Solution
Because crash already uses the [sqlparse](https://pypi.org/project/sqlparse/) SQL parser, it wasn't too difficult to re-use its tokenizer already for extracting the proper canonical SQL command from the SQL expression.
```sql
$ echo '/*foo*/ select 1' | crash
CONNECT OK
+---+
| 1 |
+---+
| 1 |
+---+
SELECT 1 row in set (0.003 sec)
```

## Review FYI
The [fundamental change](https://github.com/crate/crash/pull/432#pullrequestreview-1941195847) is very slim, but the patch grew a bit in size because software tests and corresponding mocking techniques needed to be adjusted a bit for better testability, and for backward-compatibility reasons with existing function interfaces (`str` vs. `sql.Statement`).

At a few of those spots, the diff also looks a bit strange, but the changes should be sound. Please take it into consideration when reviewing. When in doubt, look at the new code, not the diff. Thanks!

## Details

`sqlparse.sql.Statement.token_first()` provides the `skip_cm` option already:

> if *skip_cm* is ``True`` (default: ``False``), comments are ignored too.

Using `statement.get_type()` would be even more DWIM:

> The returned value is a string holding an upper-cased reprint of
> the first DML or DDL keyword. If the first token in this group
> isn't a DML or DDL keyword "UNKNOWN" is returned.
>
> Whitespaces and comments at the beginning of the statement
> are ignored.

However, that would introduce a regression that the outcome of parsing non-DML/DDL keywords like `BEGIN` would yield `UNKNOWN`, so we decided against using it for now. If you think it would be the better option, please advise correspondingly.

/cc @surister, @seut, @mfussenegger 