### PR TITLE
Fix status line display of the executed SQL command, part 2

### DIFF
--- a/crate/crash/command.py
+++ b/crate/crash/command.py
@@ -26,6 +26,7 @@ from __future__ import print_function
 
 import logging
 import os
+import re
 import sys
 from argparse import ArgumentParser, ArgumentTypeError
 from collections import namedtuple
@@ -486,7 +487,9 @@ class CrateShell:
 def stmt_type(expression: Union[str, sqlparse.sql.Statement]):
     """Extract type of statement, e.g. SELECT, INSERT, UPDATE, DELETE, ..."""
     statement = to_statement(expression)
-    return str(statement.token_first(skip_ws=True, skip_cm=True)).upper()
+    command_with_args = str(statement.token_first(skip_ws=True, skip_cm=True))
+    effective_command = re.findall(r'[\w]+', command_with_args)[0]
+    return effective_command.upper()
 
 
 def to_statement(expression: Union[str, sqlparse.sql.Statement]) -> sqlparse.sql.Statement:

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -118,6 +118,8 @@ class CommandUtilsTest(TestCase):
         self.assertEqual(stmt_type('SELECT 1; /* foo */'), 'SELECT')
         self.assertEqual(stmt_type('-- foo \n SELECT 1;'), 'SELECT')
         self.assertEqual(stmt_type('SELECT 1; -- foo'), 'SELECT')
+        # statements with arguments as part of the command
+        self.assertEqual(stmt_type('/* foo */ DENY DQL, DML, DDL, AL ON SCHEMA sys TO test;'), 'DENY')
 
     def test_decode_timeout_success(self):
         self.assertEqual(_decode_timeout(None), None)


### PR DESCRIPTION
After recent improvements (GH-432), SQL command _arguments_ came through verbatim:
```sql
DENY DQL, DML, DDL, AL ON SCHEMA sys TO test;
DENY DQL, DML, DDL, AL OK, 1 row affected (0.082 sec)
```

This fixes it to just display the effective SQL command, without any arguments:
```sql
DENY OK, 1 row affected (0.082 sec)
```
