### PR TITLE
Fix dependencies for testing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     },
     extras_require=dict(
         test=[
-            'crate[test]',
+            'crate[sqlalchemy,test]',
             'zc.customdoctests<2',
             'cratedb-toolkit[test]',
         ],


### PR DESCRIPTION
## About
geojson was missing, while it should be there. No idea why that happens. geojson is a dependency of crate[sqlalchemy]. It looks like we need to be more explicit here.

## References
- https://jenkins.crate.io/job/CrateDB/job/nightly/job/crash_test_nightly/770/console