### PR TITLE
Revert "Fix dependencies for testing"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     },
     extras_require=dict(
         test=[
-            'crate[sqlalchemy,test]',
+            'crate[test]',
             'zc.customdoctests<2',
             'cratedb-toolkit[test]',
         ],


### PR DESCRIPTION
## About

This reverts commit f749cb2f97b5d443dc92dbb20b3d719f964d0f0c.

## Why?

GH-435 was wrong, upgrading `pip` and `setuptools` instead is right.

- https://github.com/crate/jenkins-dsl/pull/1237