### PR TITLE
Fixed handling of `DuplicateKeyException` errors after crate-python 0.34

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,11 @@ Changes for crash
 Unreleased
 ==========
 
+- Fixed handling of ``DuplicateKeyException`` errors. After an improvement in
+  crate-python 0.34, this error case is conveyed through ``IntegrityError``.
+  Beforehand, a more generic ``ProgrammingError`` was used. Thanks, @romseygeek
+  and @proddata.
+
 2024/03/19 0.31.4
 =================
 

--- a/crate/crash/command.py
+++ b/crate/crash/command.py
@@ -41,7 +41,7 @@ from urllib3.exceptions import LocationParseError
 from verlib2 import Version
 
 from crate.client import connect
-from crate.client.exceptions import ConnectionError, ProgrammingError
+from crate.client.exceptions import ConnectionError, IntegrityError, ProgrammingError
 
 from ..crash import __version__ as crash_version
 from .commands import Command, built_in_commands
@@ -452,7 +452,7 @@ class CrateShell:
                 self.logger.warn(str(e))
             self.logger.warn(
                 'Use \\connect <server> to connect to one or more servers first.')
-        except ProgrammingError as e:
+        except (ProgrammingError, IntegrityError) as e:
             self.logger.critical(e.message)
             if self.error_trace and e.error_trace:
                 self.logger.critical('\n' + e.error_trace)


### PR DESCRIPTION
## Problem
Thanks for reporting, @romseygeek and @proddata.

- GH-438

## Details
After an improvement in crate-python 0.34, this error case is conveyed through `IntegrityError`. Beforehand, a more generic `ProgrammingError` was used.

Without the update, a duplicate key exception causes crash to exit prematurely and unexpectedly, when using more recent versions of crate-python.

## Solution
Now, both exception types will be handled in the same way.
