### PR TITLE
Dependencies: Update to `crate==1.0.0dev0` for validation purposes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from setuptools import setup
 requirements = [
     'colorama<1',
     'Pygments>=2.4,<3',
-    'crate>=0.35.2',
+    'crate==1.0.0dev0',
     'platformdirs<5',
     'prompt-toolkit>=3.0,<4',
     'tabulate>=0.9,<0.10',


### PR DESCRIPTION
## About
> The [CrateDB SQLAlchemy dialect](https://github.com/crate-workbench/sqlalchemy-cratedb) needs more love, so it was separated from the [DBAPI HTTP driver](https://github.com/crate/crate-python). This patch verifies the migration does not break anything, by updating to a pre-release of the upcoming `crate-1.0.0` package.

## References
- https://github.com/crate/roadmap/issues/85#issuecomment-2163344121
