### PR TITLE
Documentation: Enable version chooser [0.31]

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,1 +1,6 @@
 from crate.theme.rtd.conf.crate_crash import *
+
+# Enable version chooser.
+html_context.update({
+    "display_version": True,
+})

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-crate-docs-theme
+crate-docs-theme>=0.35.0


### PR DESCRIPTION
## About
- Enable version chooser.
- Use most recent version of crate-docs-theme.

## Preview
- https://crash--445.org.readthedocs.build/en/445/

## References
- https://github.com/crate/crash/pull/444