### PR TITLE
Documentation: Advertise `pipx` for program installation (PEP 668)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,19 +45,15 @@ Installation
 Python Package
 --------------
 
-Crash is available as a `pip`_ package.
+Crash is available as a package from PyPI.
 
-To install, run::
+To install the most recent version, run::
 
-    pip install crash
+    pipx install --upgrade crash
 
 Now, run it::
 
     crash
-
-To update, run::
-
-    pip install -U crash
 
 Standalone
 ----------

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -19,25 +19,19 @@ Installation
 Python package
 --------------
 
-Crash is available as a `pip`_ package.
+Crash is available as a package from PyPI.
 
-To install, run:
+To install the most recent version, run:
 
 .. code-block:: console
 
-    sh$ pip install crash
+    sh$ pipx install --upgrade crash
 
 Now, run it:
 
 .. code-block:: console
 
     sh$ crash
-
-To update, run:
-
-.. code-block:: console
-
-    sh$ pip install -U crash
 
 Standalone
 ----------


### PR DESCRIPTION
## About
Installing Python packages using `pip`, eventually contaminating the system Python installation, has been deprecated by default. The recommended installation method, at least as advertised by Debian, is to use `pipx`.

```
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
```

## References
- GH-443

Thanks, @bmunkholm.