### PR TITLE
Documentation: Clarify how to terminate SQL statements

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -116,7 +116,7 @@ traces (in the case of an error).
 Query
 =====
 
-When you run Crash, you will see something like this:
+When you run Crash, it will greet you with an SQL prompt:
 
 .. image:: startup.png
     :alt: A screenshot of Crash after startup

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -129,7 +129,8 @@ Queries are autocompleted as you type:
 .. image:: autocomplete.png
     :alt: A screenshot of Crash while typing a query
 
-Once you have entered your query, hit :kbd:`Enter` to run.
+Once you have entered your query, terminate it using ``;``,
+and hit :kbd:`Enter` to execute it.
 
 You should see something like this:
 


### PR DESCRIPTION
## About
This implements a suggestion to complete the documentation by educating users how to terminate SQL statements.

## References
- GH-442

Thanks, @bmunkholm.