### PR TITLE
Revert "Python: Fix "implicit namespace packages" migration"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ import io
 import os
 import re
 
-from setuptools import find_namespace_packages, setup
+from setuptools import setup
 
 requirements = [
     'colorama<1',
@@ -67,7 +67,7 @@ setup(
     platforms=['any'],
     license='Apache License 2.0',
     keywords='cratedb db data client shell',
-    packages=find_namespace_packages("src"),
+    packages=['crate.crash'],
     package_dir={"": "src"},
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This reverts commit f717e7fbe66a8c4ea7de6576067e3c7cb9beb6fe.
- GH-453

After this patch, when installing the project into a fresh sandbox environment on my workstation, the test suite fails to discover the `crate.crash` module. I don't know why this doesn't happen on CI.
