### PR TITLE
Documentation: Fix advertised `pipx` command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Crash is available as a package from PyPI.
 
 To install the most recent version, run::
 
-    pipx install --upgrade crash
+    pipx install crash
 
 Now, run it::
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -25,7 +25,7 @@ To install the most recent version, run:
 
 .. code-block:: console
 
-    sh$ pipx install --upgrade crash
+    sh$ pipx install crash
 
 Now, run it:
 


### PR DESCRIPTION
## Problem
GH-451 wasn't correct: `pipx` does not understand `--upgrade`. It slipped in on a recent "improvement" to the docs.

## Reference
- Report: [Installing crash with pipx fails](https://community.cratedb.com/t/installing-crash-with-pipx-fails/1922)
