### PR TITLE
CI: Provide Python 3.7. EOL, it was removed from recent GHA runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest']
+        os: ['ubuntu-22.04']
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         cratedb-version: ['4.8.4', '5.9.2']
         include:


### PR DESCRIPTION
What the title says.