### PR TITLE
Update to `crate-2.0.0`, which uses `orjson` for JSON marshalling

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,9 @@ Unreleased
   namespaces" for the ``crate`` namespace package, see `PEP 420`_
   and `Package Discovery and Namespace Package » Finding namespace packages`_.
 
+- Updated to ``crate-2.0.0``, which uses `orjson`_ for JSON marshalling.
+
+.. _orjson: https://github.com/ijl/orjson
 .. _Package Discovery and Namespace Package » Finding namespace packages: https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#namespace-packages
 .. _PEP 420: https://peps.python.org/pep-0420/
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from setuptools import setup
 requirements = [
     'colorama<1',
     'Pygments>=2.4,<3',
-    'crate>=1.0.0.dev2',
+    'crate>=2.0.0.dev5',
     'platformdirs<5',
     'prompt-toolkit>=3.0,<4',
     'tabulate>=0.9,<0.10',


### PR DESCRIPTION
## About
Validate and bring in an improvement to crate-python.

- https://github.com/crate/crate-python/pull/691

## References
- https://github.com/crate/cratedb-toolkit/pull/349
- https://github.com/crate/sqlalchemy-cratedb/pull/195
- https://github.com/crate/stevedore/pull/325
- https://github.com/crate/cloud-api/pull/3038
