### PR TITLE
Dependencies: Update to `crate>=2.0.0.dev6`, restoring JSON marshalling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from setuptools import setup
 requirements = [
     'colorama<1',
     'Pygments>=2.4,<3',
-    'crate>=2.0.0.dev5',
+    'crate>=2.0.0.dev6',
     'platformdirs<5',
     'prompt-toolkit>=3.0,<4',
     'tabulate>=0.9,<0.10',


### PR DESCRIPTION
## About
The fundamental patch GH-459 needs a little update, pulling in a more recent pre-release version of crate-python.

## References
- https://github.com/crate/crate-python/pull/691