### PR TITLE
Update index.rst: Readable screenshot, move down GH reference

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,17 +6,10 @@ The CrateDB Shell
 
 The CrateDB Shell (aka *Crash*) is an interactive `CLI`_ for working with CrateDB.
 
-.. image:: startup.png
-   :alt: A screenshot of Crash after startup
-
-
-.. image:: autocomplete.png
-   :alt: A screenshot of Crash while typing a query
-
-
 .. image:: query.png
    :alt: A screenshot of Crash after executing a query
 
+<br>
 
 .. rubric:: Table of contents
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,6 @@ The CrateDB Shell (aka *Crash*) is an interactive `CLI`_ for working with CrateD
 .. image:: query.png
    :alt: A screenshot of Crash after executing a query
 
-<br>
 
 .. rubric:: Table of contents
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,23 +4,16 @@
 The CrateDB Shell
 =================
 
-The CrateDB Shell (aka *Crash*) is an interactive `command-line interface`_
-(CLI) tool for working with CrateDB.
+The CrateDB Shell (aka *Crash*) is an interactive `CLI`_ for working with CrateDB.
 
-.. SEEALSO::
+.. image:: startup.png
+   :alt: A screenshot of Crash after startup
 
-   Crash is an open source project and is `hosted on GitHub`_.
+.. image:: autocomplete.png
+   :alt: A screenshot of Crash while typing a query
 
-.. sidebar:: Screenshots
-
-   .. image:: startup.png
-       :alt: A screenshot of Crash after startup
-
-   .. image:: autocomplete.png
-       :alt: A screenshot of Crash while typing a query
-
-   .. image:: query.png
-       :alt: A screenshot of Crash after executing a query
+.. image:: query.png
+   :alt: A screenshot of Crash after executing a query
 
 .. rubric:: Table of contents
 
@@ -33,5 +26,10 @@ The CrateDB Shell (aka *Crash*) is an interactive `command-line interface`_
    troubleshooting
    appendices/index
 
-.. _command-line interface: https://en.wikipedia.org/wiki/Command-line_interface
+.. SEEALSO::
+
+   Crash is an open source project and is `hosted on GitHub`_.
+
+
+.. _CLI: https://en.wikipedia.org/wiki/Command-line_interface
 .. _hosted on GitHub: https://github.com/crate/crash

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,11 +9,14 @@ The CrateDB Shell (aka *Crash*) is an interactive `CLI`_ for working with CrateD
 .. image:: startup.png
    :alt: A screenshot of Crash after startup
 
+
 .. image:: autocomplete.png
    :alt: A screenshot of Crash while typing a query
 
+
 .. image:: query.png
    :alt: A screenshot of Crash after executing a query
+
 
 .. rubric:: Table of contents
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Move down Github admonition (it's secondary) and make screenshots visible in size.
Keep only last screenshot as the other two just leads up to the third.

## Preview

https://crash--467.org.readthedocs.build/en/467/


## Screenshots

### Before

<img width="761" alt="image" src="https://github.com/user-attachments/assets/9e780bee-7e97-43fe-8afd-f4bd51e5dcbc" />


### After

<img width="723" alt="image" src="https://github.com/user-attachments/assets/c8f1402c-3bd8-4d40-b43e-f88120e6ecdf" />


