### PR TITLE
CI: Stop building `docs` on `macos-latest`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,12 +20,8 @@ concurrency:
 
 jobs:
   documentation:
-    name: Build docs on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+    name: Run link checker
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
It saves a few cycles on the linkchecker, both on GHA and on remote web servers.
- GH-469