### PR TITLE
Remove page local toc

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -4,11 +4,6 @@
 Getting started
 ===============
 
-.. rubric:: Table of contents
-
-.. contents::
-   :local:
-
 Installation
 ============
 

--- a/docs/run.rst
+++ b/docs/run.rst
@@ -12,12 +12,6 @@ This document covers the basics of running Crash from the `command-line`_.
 
 .. _options:
 
-.. rubric:: Table of contents
-
-.. contents::
-   :local:
-   :depth: 1
-
 Command-line options
 ====================
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Page local toc's are redundant now that we have them automatically in the right side.
