### PR TITLE
make check reported an error

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -86,7 +86,7 @@ SRC_MAKE      := $(MAKE) -f $(SRC_DIR)/rules.mk
 
 # Parse the JSON file
 BUILD_VERSION := $(shell cat $(BUILD_JSON) | \
-    python -c 'import json, sys; print(json.load(sys.stdin)["message"])')
+    python3 -c 'import json, sys; print(json.load(sys.stdin)["message"])')
 
 ifeq ($(BUILD_VERSION),)
 $(error No build version specified in `$(BUILD_JSON)`.)

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -13,7 +13,7 @@ If you are connecting to `CrateDB`_, for example like this::
 
     crash --hosts 'http://localhost:4200' -U 'admin' -W
 
-... and ``crash`` responds with a connection error message like this::
+and ``crash`` responds with a connection error message like this::
 
     CONNECT ERROR
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
`make check` gave this error:

 ../docs/troubleshooting.rst
 16:1  error  Consider using the '…' symbol   proselint.Typography 
              instead of '...'.                                    