### PR TITLE
Documentation: Remove references to standalone builds

### DIFF
--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -63,24 +63,6 @@ Python interpreter or multiple `Python versions`_ on your workstation using
 `uv`_, by supplying the ``--python`` command-line option, or by defining the
 `UV_PYTHON`_ environment variable prior to creating the virtualenv.
 
-Standalone Executable
-=====================
-
-To build a standalone executable, you can use shiv_::
-
-    shiv -p /usr/bin/python -c crash -o crash.pyz crash
-
-Run the executable like so::
-
-    ./crash.pyz
-
-
-Standalone Deployment
-=====================
-
-The standalone executable is built and deployed by a `Jenkins`_ job.
-
-
 Documentation
 =============
 
@@ -146,9 +128,6 @@ To create a new release, you must:
   that releases the new version to PyPI at https://pypi.org/project/crash/
 
 - Designate the new release on GitHub at https://github.com/crate/crash/releases
-
-- Run the ``crash_standalone`` job on Jenkins in order to produce and publish
-  a self-contained executable to https://cdn.crate.io/downloads/releases/
 
 - Archive docs for old releases (see below)
 

--- a/README.rst
+++ b/README.rst
@@ -55,27 +55,6 @@ Now, run it::
 
     crash
 
-Standalone
-----------
-
-Crash is also available as a standalone executable that includes all the
-necessary dependencies.
-
-First, download the executable file::
-
-    curl -o crash https://cdn.crate.io/downloads/releases/crash_standalone_latest
-
-Then, set the executable bit::
-
-    chmod +x crash
-
-Now, run it::
-
-    ./crash
-
-If you would like to run ``crash`` from any directory, and without the leading
-``./``, the file has to be in a directory that is on your `PATH`_.
-
 Troubleshooting
 ===============
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -24,49 +24,6 @@ Now, run it:
 
     sh$ crash
 
-Standalone
-----------
-
-Crash is also available as a standalone executable that includes all the
-necessary dependencies, and can be run as long as Python (>= 3.4) is available
-on your system.
-
-First, download the executable file:
-
-.. code-block:: console
-
-    sh$ curl -o crash https://cdn.crate.io/downloads/releases/crash_standalone_latest
-
-Then, set the executable bit:
-
-.. code-block:: console
-
-    sh$ chmod +x crash
-
-Now, run it:
-
-.. code-block:: console
-
-    sh$ ./crash
-
-If you would like to run ``crash`` from any directory, and without the leading
-``./``, the file has to be in a directory that is on your `PATH`_.
-
-Legacy versions
-...............
-
-For Python 2.7 and 3.3 please download version 0.23.0 from the CDN:
-
-.. code-block:: console
-
-    sh$ curl -o crash https://cdn.crate.io/downloads/releases/crash_standalone_0.23.0
-
-For Python 2.6 please download version 0.16.2 from the CDN:
-
-.. code-block:: console
-
-    sh$ curl -o crash https://cdn.crate.io/downloads/releases/crash_standalone_0.16.2
-
 Run
 ===
 


### PR DESCRIPTION
## About
Standalone builds are no longer viable after crate-python started using the `orjson` package, which is distributed as binary wheels.

## References
- https://github.com/crate/crash/issues/488
- https://github.com/crate/jenkins-dsl/pull/1333
