### PR TITLE
Dependencies: Permit installation of crate-python up to any 2.x.x release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from setuptools import setup
 requirements = [
     'colorama<1',
     'Pygments>=2.4,<3',
-    'crate>=2.0.0.dev6',
+    'crate<3',
     'platformdirs<5',
     'prompt-toolkit>=3.0,<4',
     'tabulate>=0.9,<0.10',


### PR DESCRIPTION
## About
crash is compatible with all versions of crate-python up until the recent 2.1.1, and will likely be compatible with higher releases of the 2.x.x series.

## Details
I've verified all those installations of crash can connect to CrateDB successfully, to support the relaxed version constraint `crate<3`.
```shell
uv pip install --upgrade crash "crate<0.10"
uv pip install --upgrade crash "crate<1"
uv pip install --upgrade crash "crate<2"
uv pip install --upgrade crash "crate<3"
```

## References
- https://github.com/crate/crate-python/issues/787