### PR TITLE
Project: Use SPDX license expression and remove Trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/x-rst',
     platforms=['any'],
-    license='Apache License 2.0',
+    license='Apache-2.0',
     keywords='cratedb db data client shell',
     packages=["crate", "crate.crash"],
     package_dir={"": "src"},
@@ -94,7 +94,6 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
## About
A deprecation warning is emitted when building the package.
```python
SetuptoolsDeprecationWarning: License classifiers are deprecated
```
```text
Please consider removing the following classifiers in favor of a SPDX license expression:

    License :: OSI Approved :: Apache Software License
```

## Solution
Modernize project metadata.

## References
- [CI run #22738439978](https://github.com/crate/crash/actions/runs/22738439978/job/65945765770#step:4:111)
