### PR TITLE
Feature: add \shards command to track relocations

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for crash
 Unreleased
 ==========
 
+- Added ``\shards`` to show shard relocation progress. With optinal arguments
+  ``state`` and ``relocating``.
+
 2026/02/09 0.32.0
 =================
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,11 +5,8 @@ Changes for crash
 Unreleased
 ==========
 
-- Added ``\shards`` to show shard relocation progress. With optional arguments
-  ``state`` and ``relocating``.
+- Added ``\shards`` to show shard relocation progress. With optional argument ``info``.
 
-- Added ``\shards`` to show shard relocation progress. With optinal arguments
-  ``state`` and ``relocating``.
 
 2026/02/09 0.32.0
 =================

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,9 @@ Unreleased
 - Added ``\shards`` to show shard relocation progress. With optional arguments
   ``state`` and ``relocating``.
 
+- Added ``\shards`` to show shard relocation progress. With optinal arguments
+  ``state`` and ``relocating``.
+
 2026/02/09 0.32.0
 =================
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ Changes for crash
 Unreleased
 ==========
 
-- Added ``\shards`` to show shard relocation progress. With optinal arguments
+- Added ``\shards`` to show shard relocation progress. With optional arguments
   ``state`` and ``relocating``.
 
 2026/02/09 0.32.0

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -56,10 +56,11 @@ Every command starts with a ``\`` character.
 | ``\r <FILENAME>``      | Reads statements from ``<FILENAME>`` and execute    |
 |                        | them.                                               |
 +------------------------+-----------------------------------------------------+
-| ``\shards [all]``      | Queries the ``sys`` tables aggregating shards status|
-|                        | followed by filtering shards relocation and         |
-|                        | initialization, unless ``all``  is used. In which   |
-|                        | case no filter is applied.                          |
+| ``\shards [VIEW]``     | Queries ``sys.shards`` table and computes relocation|
+|                        | progress progress per table. If ``VIEW`` is instead:|
+|                        |                                                     |
+|                        | - ``state`` provides aggregeration on shard state   |
+|                        | - ``relocating`` tracks which shards are relocated  |
 +------------------------+-----------------------------------------------------+
 | ``\sysinfo``           | Query the ``sys`` tables for system and cluster     |
 |                        | information.                                        |

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -56,6 +56,11 @@ Every command starts with a ``\`` character.
 | ``\r <FILENAME>``      | Reads statements from ``<FILENAME>`` and execute    |
 |                        | them.                                               |
 +------------------------+-----------------------------------------------------+
+| ``\shards [all]``      | Queries the ``sys`` tables aggregating shards status|
+|                        | followed by filtering shards relocation and         |
+|                        | initialization, unless ``all``  is used. In which   |
+|                        | case no filter is applied.                          |
++------------------------+-----------------------------------------------------+
 | ``\sysinfo``           | Query the ``sys`` tables for system and cluster     |
 |                        | information.                                        |
 +------------------------+-----------------------------------------------------+

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -56,10 +56,14 @@ Every command starts with a ``\`` character.
 | ``\r <FILENAME>``      | Reads statements from ``<FILENAME>`` and execute    |
 |                        | them.                                               |
 +------------------------+-----------------------------------------------------+
-| ``\shards [MODE]``     | Queries ``sys.shards`` table shows an overview on   |
-|                        | the state of all shards. Providing ``MODE``  shows: |
+| ``\shards [MODE]``     | Shows the cluster's shard information. Either as    |
+|                        | as global overview or per-table.                    |
 |                        |                                                     |
-|                        | - ``info`` descriminates shard relocation per table |
+|                        | ``MODE`` can be one of the following:               |
+|                        |                                                     |
+|                        | - not set (defaults to ``overview``)                |
+|                        | - ``overview`` (grouped by shard state)             |
+|                        | - ``per-table`` (grouped by table)                  |
 +------------------------+-----------------------------------------------------+
 | ``\sysinfo``           | Query the ``sys`` tables for system and cluster     |
 |                        | information.                                        |

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -56,11 +56,10 @@ Every command starts with a ``\`` character.
 | ``\r <FILENAME>``      | Reads statements from ``<FILENAME>`` and execute    |
 |                        | them.                                               |
 +------------------------+-----------------------------------------------------+
-| ``\shards [VIEW]``     | Queries ``sys.shards`` table and computes relocation|
-|                        | progress progress per table. If ``VIEW`` is instead:|
+| ``\shards [MODE]``     | Queries ``sys.shards`` table shows an overview on   |
+|                        | the state of all shards. Providing ``MODE``  shows: |
 |                        |                                                     |
-|                        | - ``state`` provides aggregeration on shard state   |
-|                        | - ``relocating`` tracks which shards are relocated  |
+|                        | - ``info`` descriminates shard relocation per table |
 +------------------------+-----------------------------------------------------+
 | ``\sysinfo``           | Query the ``sys`` tables for system and cluster     |
 |                        | information.                                        |

--- a/src/crate/crash/commands.py
+++ b/src/crate/crash/commands.py
@@ -234,6 +234,51 @@ class CheckCommand(Command):
             cmd.logger.warn('No check for {}'.format(check_name))
 
 
+class ShardsCommand(Command):
+    """ short summary for shards and their relocation (use `all` as argument for longer output) """
+
+    SHORT_STMT = """SELECT routing_state, state, COUNT(*) AS shard_count, SUM(num_docs) as num_docs, SUM(size) / 1073741824.0 as size_gb
+        FROM sys.shards
+        GROUP BY routing_state, state
+        ORDER BY shard_count DESC;
+    """
+
+    RELOC_STMT = """
+        SELECT node['name'] as name, id, recovery['stage'] as stage, recovery['size']['percent'] AS "%", routing_state, state, primary, table_name, relocating_node, size / 1024 as size_kb, partition_ident
+        FROM sys.shards
+        WHERE routing_state NOT IN ('STARTED')
+        ORDER BY id, name;
+    """
+
+    ALLSHARDS_STMT = """
+        SELECT node['name'] as name, id, recovery['stage'] as stage, recovery['size']['percent'] AS "%", routing_state, state, primary, table_name, relocating_node, size / 1024 as size_kb, partition_ident
+        FROM sys.shards
+        ORDER BY id, name;
+    """
+
+    OPTIONS = ('all',)
+
+    def complete(self, cmd, text):
+        return (i for i in self.OPTIONS if i.startswith(text) or text == '')
+
+    def execute(self, cmd, stmt):
+        success = cmd._exec(stmt)
+        cmd.exit_code = cmd.exit_code or int(not success)
+        if not success:
+            cmd.logger.warn("FAILED")
+            return False
+
+        cur = cmd.cursor
+        shards = cur.fetchall()
+        if len(shards):
+            cmd.pprint(shards, [c[0] for c in cur.description])
+        return True
+
+    def __call__(self, cmd, *args, **kwargs):
+        for stmt in (self.SHORT_STMT, self.RELOC_STMT if 'all' not in args else self.ALLSHARDS_STMT):
+            self.execute(cmd, stmt)
+
+
 built_in_commands = {
     '?': HelpCommand(),
     'r': ReadFileCommand(),
@@ -243,4 +288,5 @@ built_in_commands = {
     'verbose': ToggleVerboseCommand(),
     'check': CheckCommand(),
     'pager': SetPager(),
+    'shards': ShardsCommand(),
 }

--- a/src/crate/crash/commands.py
+++ b/src/crate/crash/commands.py
@@ -253,24 +253,24 @@ class ShardsCommand(Command):
     """
 
     INFO_STMT = """
-SELECT
-    schema_name,
-    table_name,
-    partition_ident,
-    COUNT(*)
-        AS total_shards,
-    SUM(size)
-        As total_size,
-    COUNT(*) FILTER (WHERE routing_state = 'RELOCATING')
-        AS relocating_shards,
-    SUM(size) FILTER (WHERE routing_state = 'RELOCATING')
-        AS relocating_size,
-    100.0 * SUM(size) FILTER(WHERE routing_state != 'RELOCATING') / SUM(size)
-        AS relocated_percent
-FROM sys.shards
-WHERE routing_state != 'UNASSIGNED'
-GROUP BY schema_name, table_name, partition_ident
-ORDER BY relocated_percent, schema_name, table_name, partition_ident;
+        SELECT
+            schema_name,
+            table_name,
+            partition_ident,
+            COUNT(*)
+                AS total_shards,
+            SUM(size)
+                As total_size,
+            COUNT(*) FILTER (WHERE routing_state = 'RELOCATING')
+                AS relocating_shards,
+            SUM(size) FILTER (WHERE routing_state = 'RELOCATING')
+                AS relocating_size,
+            100.0 * SUM(size) FILTER(WHERE routing_state != 'RELOCATING') / SUM(size)
+                AS relocated_percent
+        FROM sys.shards
+        WHERE routing_state != 'UNASSIGNED'
+        GROUP BY schema_name, table_name, partition_ident
+        ORDER BY relocated_percent, schema_name, table_name, partition_ident;
     """
 
     OPTIONS = {
@@ -302,7 +302,6 @@ ORDER BY relocated_percent, schema_name, table_name, partition_ident;
             self.execute(cmd, stmt)
         else:
             cmd.logger.critical(f'Command argument not supported (available options: {", ".join(f"`{_a}`" for _a in self.OPTIONS.keys())}).')
-            return
 
 
 built_in_commands = {

--- a/src/crate/crash/commands.py
+++ b/src/crate/crash/commands.py
@@ -238,6 +238,21 @@ class ShardsCommand(Command):
     """shows progress of shards relocation (optional arguments: `state` and `relocating`)"""
 
     DEFAULT_STMT = """
+        SELECT
+            state,
+            primary,
+            COUNT(*)
+                AS shard_count,
+            SUM(num_docs)
+                AS num_docs,
+            SUM(size) / 1024^3
+                AS size_gb
+        FROM sys.shards
+        GROUP BY state, primary
+        ORDER BY state, primary;
+    """
+
+    INFO_STMT = """
 SELECT
     schema_name,
     table_name,
@@ -258,24 +273,9 @@ GROUP BY schema_name, table_name, partition_ident
 ORDER BY relocated_percent, schema_name, table_name, partition_ident;
     """
 
-    STATE_STMT = """
-        SELECT
-            state,
-            primary,
-            COUNT(*)
-                AS shard_count,
-            SUM(num_docs)
-                AS num_docs,
-            SUM(size) / 1024^3
-                AS size_gb
-        FROM sys.shards
-        GROUP BY state, primary
-        ORDER BY state, primary;
-    """
-
 
     OPTIONS = {
-        "state": STATE_STMT,
+        "info": INFO_STMT,
     }
 
     def complete(self, cmd, text):

--- a/src/crate/crash/commands.py
+++ b/src/crate/crash/commands.py
@@ -260,16 +260,17 @@ ORDER BY relocated_percent, schema_name, table_name, partition_ident;
 
     STATE_STMT = """
         SELECT
-            routing_state,
+            state,
+            primary,
             COUNT(*)
                 AS shard_count,
             SUM(num_docs)
                 AS num_docs,
-            SUM(size) / 1073741824.0
+            SUM(size) / 1024^3
                 AS size_gb
         FROM sys.shards
-        GROUP BY routing_state
-        ORDER BY routing_state;
+        GROUP BY state, primary
+        ORDER BY state, primary;
     """
 
     RELOC_STMT = """

--- a/src/crate/crash/commands.py
+++ b/src/crate/crash/commands.py
@@ -245,7 +245,7 @@ class ShardsCommand(Command):
                 AS shard_count,
             SUM(num_docs)
                 AS num_docs,
-            SUM(size) / 1024^3
+            SUM(size) / 1073741824.0
                 AS size_gb
         FROM sys.shards
         GROUP BY state, primary

--- a/src/crate/crash/commands.py
+++ b/src/crate/crash/commands.py
@@ -238,24 +238,24 @@ class ShardsCommand(Command):
     """shows progress of shards relocation (optional arguments: `state` and `relocating`)"""
 
     DEFAULT_STMT = """
-        SELECT
-            table_name,
-            COUNT(*)
-                AS total_shards,
-            SUM(num_docs)
-                AS total_num_docs,
-            SUM(size)
-                As total_sum_shard_size,
-            SUM(CASE WHEN routing_state = 'RELOCATING' THEN 1 ELSE 0 END)
-                AS relocating_shards,
-            SUM(CASE WHEN routing_state = 'RELOCATING' THEN size ELSE 0 END)
-                AS relocating_size,
-            100.0 * SUM(CASE WHEN routing_state != 'RELOCATING' THEN size ELSE 0 END) / CAST(SUM(size) as DOUBLE)
-                AS relocated_percent
-        FROM sys.shards
-        WHERE routing_state != 'UNASSIGNED'
-        GROUP BY table_name
-        ORDER BY table_name;
+SELECT
+table_name,
+    COUNT(*)
+        AS total_shards,
+    SUM(num_docs)
+        AS total_num_docs,
+    SUM(size)
+        As total_sum_shard_size,
+    SUM(CASE WHEN routing_state = 'RELOCATING' THEN 1 ELSE 0 END)
+        AS relocating_shards,
+    SUM(CASE WHEN routing_state = 'RELOCATING' THEN size ELSE 0 END)
+        AS relocating_size,
+    100.0 * SUM(CASE WHEN routing_state != 'RELOCATING' THEN size ELSE 0 END) / CAST(SUM(size) as DOUBLE)
+        AS relocated_percent
+FROM sys.shards
+WHERE routing_state != 'UNASSIGNED'
+GROUP BY table_name
+ORDER BY relocated_percent, table_name;
     """
 
     STATE_STMT = """

--- a/src/crate/crash/commands.py
+++ b/src/crate/crash/commands.py
@@ -308,10 +308,7 @@ class ShardsCommand(Command):
 
         cur = cmd.cursor
         shards = cur.fetchall()
-        if len(shards):
-            cmd.pprint(shards, [c[0] for c in cur.description])
-        else:
-            cmd.logger.info("No shards relocating!")
+        cmd.pprint(shards, [c[0] for c in cur.description])
         return True
 
     def __call__(self, cmd, *args, **kwargs):
@@ -322,6 +319,9 @@ class ShardsCommand(Command):
         stmt = self.OPTIONS.get(args[0].strip())
         if stmt:
             self.execute(cmd, stmt)
+        else:
+            cmd.logger.critical(f'Command argument not supported (available options: {", ".join(f"`{_a}`" for _a in self.OPTIONS.keys())}).')
+            return
 
 
 built_in_commands = {

--- a/src/crate/crash/commands.py
+++ b/src/crate/crash/commands.py
@@ -235,31 +235,69 @@ class CheckCommand(Command):
 
 
 class ShardsCommand(Command):
-    """ short summary for shards and their relocation (use `all` as argument for longer output) """
+    """shows progress of shards relocation (optional arguments: `state` and `relocating`)"""
 
-    SHORT_STMT = """SELECT routing_state, state, COUNT(*) AS shard_count, SUM(num_docs) as num_docs, SUM(size) / 1073741824.0 as size_gb
+    DEFAULT_STMT = """
+        SELECT
+            table_name,
+            COUNT(*)
+                AS total_shards,
+            SUM(num_docs)
+                AS total_num_docs,
+            SUM(size)
+                As total_sum_shard_size,
+            SUM(CASE WHEN routing_state = 'RELOCATING' THEN 1 ELSE 0 END)
+                AS relocating_shards,
+            SUM(CASE WHEN routing_state = 'RELOCATING' THEN size ELSE 0 END)
+                AS relocating_size,
+            100.0 * SUM(CASE WHEN routing_state != 'RELOCATING' THEN size ELSE 0 END) / CAST(SUM(size) as DOUBLE)
+                AS relocated_percent
         FROM sys.shards
-        GROUP BY routing_state, state
-        ORDER BY shard_count DESC;
+        WHERE routing_state != 'UNASSIGNED'
+        GROUP BY table_name
+        ORDER BY table_name;
+    """
+
+    STATE_STMT = """
+        SELECT
+            routing_state,
+            COUNT(*)
+                AS shard_count,
+            SUM(num_docs)
+                AS num_docs,
+            SUM(size) / 1073741824.0
+                AS size_gb
+        FROM sys.shards
+        GROUP BY routing_state
+        ORDER BY routing_state;
     """
 
     RELOC_STMT = """
-        SELECT node['name'] as name, id, recovery['stage'] as stage, recovery['size']['percent'] AS "%", routing_state, state, primary, table_name, relocating_node, size / 1024 as size_kb, partition_ident
+        SELECT
+            table_name,
+            node['name'],
+            id,
+            recovery['stage'],
+            size,
+            routing_state,
+            state,
+            primary,
+            relocating_node,
+            size / 1024.0
+                AS size_kb,
+            partition_ident
         FROM sys.shards
-        WHERE routing_state NOT IN ('STARTED')
-        ORDER BY id, name;
+        WHERE routing_state = 'RELOCATING'
+        ORDER BY table_name, id, node['name'];
     """
 
-    ALLSHARDS_STMT = """
-        SELECT node['name'] as name, id, recovery['stage'] as stage, recovery['size']['percent'] AS "%", routing_state, state, primary, table_name, relocating_node, size / 1024 as size_kb, partition_ident
-        FROM sys.shards
-        ORDER BY id, name;
-    """
-
-    OPTIONS = ('all',)
+    OPTIONS = {
+        "state": STATE_STMT,
+        "relocating": RELOC_STMT,
+    }
 
     def complete(self, cmd, text):
-        return (i for i in self.OPTIONS if i.startswith(text) or text == '')
+        return (i for i in self.OPTIONS if i.startswith(text) or text.isspace())
 
     def execute(self, cmd, stmt):
         success = cmd._exec(stmt)
@@ -272,21 +310,28 @@ class ShardsCommand(Command):
         shards = cur.fetchall()
         if len(shards):
             cmd.pprint(shards, [c[0] for c in cur.description])
+        else:
+            cmd.logger.info("No shards relocating!")
         return True
 
     def __call__(self, cmd, *args, **kwargs):
-        for stmt in (self.SHORT_STMT, self.RELOC_STMT if 'all' not in args else self.ALLSHARDS_STMT):
+        if len(args) == 0:
+            self.execute(cmd, self.DEFAULT_STMT)
+            return
+
+        stmt = self.OPTIONS.get(args[0].strip())
+        if stmt:
             self.execute(cmd, stmt)
 
 
 built_in_commands = {
-    '?': HelpCommand(),
-    'r': ReadFileCommand(),
-    'format': SwitchFormatCommand(),
-    'autocomplete': ToggleAutocompleteCommand(),
-    'autocapitalize': ToggleAutoCapitalizeCommand(),
-    'verbose': ToggleVerboseCommand(),
-    'check': CheckCommand(),
-    'pager': SetPager(),
-    'shards': ShardsCommand(),
+    "?": HelpCommand(),
+    "r": ReadFileCommand(),
+    "format": SwitchFormatCommand(),
+    "autocomplete": ToggleAutocompleteCommand(),
+    "autocapitalize": ToggleAutoCapitalizeCommand(),
+    "verbose": ToggleVerboseCommand(),
+    "check": CheckCommand(),
+    "pager": SetPager(),
+    "shards": ShardsCommand(),
 }

--- a/src/crate/crash/commands.py
+++ b/src/crate/crash/commands.py
@@ -273,28 +273,9 @@ ORDER BY relocated_percent, schema_name, table_name, partition_ident;
         ORDER BY state, primary;
     """
 
-    RELOC_STMT = """
-        SELECT
-            table_name,
-            node['name'],
-            id,
-            recovery['stage'],
-            size,
-            routing_state,
-            state,
-            primary,
-            relocating_node,
-            size / 1024.0
-                AS size_kb,
-            partition_ident
-        FROM sys.shards
-        WHERE routing_state = 'RELOCATING'
-        ORDER BY table_name, id, node['name'];
-    """
 
     OPTIONS = {
         "state": STATE_STMT,
-        "relocating": RELOC_STMT,
     }
 
     def complete(self, cmd, text):

--- a/src/crate/crash/commands.py
+++ b/src/crate/crash/commands.py
@@ -235,7 +235,7 @@ class CheckCommand(Command):
 
 
 class ShardsCommand(Command):
-    """shows progress of shards relocation (optional arguments: `state` and `relocating`)"""
+    """shows shards state, optionally per table, e.g. \\shards info"""
 
     DEFAULT_STMT = """
         SELECT
@@ -272,7 +272,6 @@ WHERE routing_state != 'UNASSIGNED'
 GROUP BY schema_name, table_name, partition_ident
 ORDER BY relocated_percent, schema_name, table_name, partition_ident;
     """
-
 
     OPTIONS = {
         "info": INFO_STMT,

--- a/src/crate/crash/commands.py
+++ b/src/crate/crash/commands.py
@@ -239,23 +239,23 @@ class ShardsCommand(Command):
 
     DEFAULT_STMT = """
 SELECT
-table_name,
+    schema_name,
+    table_name,
+    partition_ident,
     COUNT(*)
         AS total_shards,
-    SUM(num_docs)
-        AS total_num_docs,
     SUM(size)
-        As total_sum_shard_size,
-    SUM(CASE WHEN routing_state = 'RELOCATING' THEN 1 ELSE 0 END)
+        As total_size,
+    COUNT(*) FILTER (WHERE routing_state = 'RELOCATING')
         AS relocating_shards,
-    SUM(CASE WHEN routing_state = 'RELOCATING' THEN size ELSE 0 END)
+    SUM(size) FILTER (WHERE routing_state = 'RELOCATING')
         AS relocating_size,
-    100.0 * SUM(CASE WHEN routing_state != 'RELOCATING' THEN size ELSE 0 END) / CAST(SUM(size) as DOUBLE)
+    100.0 * SUM(size) FILTER(WHERE routing_state != 'RELOCATING') / SUM(size)
         AS relocated_percent
 FROM sys.shards
 WHERE routing_state != 'UNASSIGNED'
-GROUP BY table_name
-ORDER BY relocated_percent, table_name;
+GROUP BY schema_name, table_name, partition_ident
+ORDER BY relocated_percent, schema_name, table_name, partition_ident;
     """
 
     STATE_STMT = """

--- a/src/crate/crash/commands.py
+++ b/src/crate/crash/commands.py
@@ -235,9 +235,9 @@ class CheckCommand(Command):
 
 
 class ShardsCommand(Command):
-    """shows shards state, optionally per table, e.g. \\shards info"""
+    """shows shards overview, optionally per table, e.g. \\shards info"""
 
-    DEFAULT_STMT = """
+    OVERVIEW_STMT = """
         SELECT
             state,
             primary,
@@ -274,7 +274,8 @@ class ShardsCommand(Command):
     """
 
     OPTIONS = {
-        "info": INFO_STMT,
+        "overview": OVERVIEW_STMT,
+        "per-table": INFO_STMT,
     }
 
     def complete(self, cmd, text):
@@ -294,7 +295,7 @@ class ShardsCommand(Command):
 
     def __call__(self, cmd, *args, **kwargs):
         if len(args) == 0:
-            self.execute(cmd, self.DEFAULT_STMT)
+            self.execute(cmd, self.OVERVIEW_STMT)
             return
 
         stmt = self.OPTIONS.get(args[0].strip())

--- a/src/crate/crash/commands.py
+++ b/src/crate/crash/commands.py
@@ -235,7 +235,7 @@ class CheckCommand(Command):
 
 
 class ShardsCommand(Command):
-    """shows shards overview, optionally per table, e.g. \\shards info"""
+    """shows shards overview, optionally per table, e.g. \\shards per-table"""
 
     OVERVIEW_STMT = """
         SELECT

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -270,13 +270,12 @@ class ChecksCommandTest(TestCase):
 
 class ShardsCommandTest(TestCase):
     @patch('crate.crash.command.CrateShell')
-    def test_shards_command(self,cmd):
+    def test_shards_command_default(self,cmd):
         rows = [
-            ['table1','1','10','1024','0','0','100.0'],
-            ['table2','2','20','2048','1','1024','50.0'],
-            ['table3','3','30','3072','2','2048','33.3'],
+            ['RELOCATING','FALSE','2','33334465','9.307963063940406'],
+            ['STARTED','TRUE','1010','166665535','26.309150873683393'],
         ]
-        cols = [('table_name', ), (' total_shards', ), (' total_num_docs', ), (' total_sum_shard_size', ), (' relocating_shards', ), (' relocating_size', ), (' relocated_percent')]
+        cols = [('state', ), ('primary',), ('shard_count', ), ('num_docs', ), ('size_gb', )]
         cmd._exec.return_value = True
         cmd.cursor.fetchall.return_value = rows
         cmd.cursor.description = cols
@@ -285,39 +284,35 @@ class ShardsCommandTest(TestCase):
         cmd.pprint.assert_called_with(rows, [c[0] for c in cols])
 
     @patch('crate.crash.command.CrateShell')
-    def test_shards_command_state(self,cmd):
+    def test_shards_command_info(self,cmd):
         rows = [
-            ['RELOCATING','2','33334465','9.307963063940406'],
-            ['STARTED','1010','166665535','26.309150873683393'],
+            ['doc','table1','','1','10','1024','0','100.0'],
+            ['doc','table2','','2','20','2048','1','50.0'],
+            ['doc','table3','','3','30','3072','2','33.3'],
         ]
-        cols = [('routing_state', ), ('shard_count', ), ('num_docs', ), ('size_gb', )]
+        cols = [('schema_name',),('table_name',),('partition_ident',),('total_shards',),('total_size',),('relocating_shards',),('relocating_size',),('relocated_percent',)]
         cmd._exec.return_value = True
         cmd.cursor.fetchall.return_value = rows
         cmd.cursor.description = cols
 
-        ShardsCommand()(cmd,"state")
+        ShardsCommand()(cmd, "info")
         cmd.pprint.assert_called_with(rows, [c[0] for c in cols])
 
+
     @patch('crate.crash.command.CrateShell')
-    def test_shards_command_relocating_none(self,cmd):
+    def test_shards_command_default_none(self,cmd):
         cmd._exec.return_value = True
         cmd.cursor.fetchall.return_value = []
-        ShardsCommand()(cmd,"relocating")
+        ShardsCommand()(cmd)
         cmd.logger.info.assert_not_called()
 
     @patch('crate.crash.command.CrateShell')
-    def test_shards_command_relocating(self,cmd):
-        rows = [
-            ['table1','node02','1','DONE','4997198327','RELOCATING','STARTED','TRUE','d63zx99jSfWjr5wUykEXWQ','4880076.4912109375',''],
-            ['table1','node01','2','DONE','4997150911','RELOCATING','STARTED','TRUE','d63zx99jSfWjr5wUykEXWQ','4880030.1865234375',''],
-        ]
-        cols = [('table_name',),('node[\'name\']',),('id',),('recovery[\'stage\']',),('size',),('routing_state',),('state',),('primary',),('relocating_node',),('size_kb',),('partition_ident',)]
+    def test_shards_command_info_none(self,cmd):
         cmd._exec.return_value = True
-        cmd.cursor.fetchall.return_value = rows
-        cmd.cursor.description = cols
+        cmd.cursor.fetchall.return_value = []
+        ShardsCommand()(cmd,"info")
+        cmd.logger.info.assert_not_called()
 
-        ShardsCommand()(cmd,"state")
-        cmd.pprint.assert_called_with(rows, [c[0] for c in cols])
 
 @patch('crate.client.connection.Cursor', fake_cursor())
 class CommentsTest(TestCase):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -272,11 +272,11 @@ class ShardsCommandTest(TestCase):
     @patch('crate.crash.command.CrateShell')
     def test_shards_command(self,cmd):
         rows = [
-            ["table1","    6", "100000000","30065115537 ","1 ","      5038203304 ","  83.2423617404707 "],
-            ["table2","    6", "100000000"," 8178261348 ","0 ","               0 "," 100.0             "],
-            ["table3"," 1000", "        0","     208000 ","0 ","               0 "," 100.0             "],
+            ['table1','1','10','1024','0','0','100.0'],
+            ['table2','2','20','2048','1','1024','50.0'],
+            ['table3','3','30','3072','2','2048','33.3'],
         ]
-        cols = [("table_name ", ), (" total_shards ", ), (" total_num_docs ", ), (" total_sum_shard_size ", ), (" relocating_shards ", ), (" relocating_size ", ), (" relocated_percent")]
+        cols = [('table_name', ), (' total_shards', ), (' total_num_docs', ), (' total_sum_shard_size', ), (' relocating_shards', ), (' relocating_size', ), (' relocated_percent')]
         cmd._exec.return_value = True
         cmd.cursor.fetchall.return_value = rows
         cmd.cursor.description = cols
@@ -287,10 +287,10 @@ class ShardsCommandTest(TestCase):
     @patch('crate.crash.command.CrateShell')
     def test_shards_command_state(self,cmd):
         rows = [
-            ["RELOCATING","2","33334465","9.307963063940406"],
-            ["STARTED","1010","166665535","26.309150873683393"],
+            ['RELOCATING','2','33334465','9.307963063940406'],
+            ['STARTED','1010','166665535','26.309150873683393'],
         ]
-        cols = [("routing_state", ), ("shard_count", ), ("num_docs", ), ("size_gb", )]
+        cols = [('routing_state', ), ('shard_count', ), ('num_docs', ), ('size_gb', )]
         cmd._exec.return_value = True
         cmd.cursor.fetchall.return_value = rows
         cmd.cursor.description = cols
@@ -303,15 +303,15 @@ class ShardsCommandTest(TestCase):
         cmd._exec.return_value = True
         cmd.cursor.fetchall.return_value = []
         ShardsCommand()(cmd,"relocating")
-        cmd.logger.info.assert_called_with('No shards relocating!')
+        cmd.logger.info.assert_not_called()
 
     @patch('crate.crash.command.CrateShell')
     def test_shards_command_relocating(self,cmd):
         rows = [
-            ["table1","node02","1","DONE","4997198327","RELOCATING","STARTED","TRUE","d63zx99jSfWjr5wUykEXWQ","4880076.4912109375",""],
-            ["table1","node01","2","DONE","4997150911","RELOCATING","STARTED","TRUE","d63zx99jSfWjr5wUykEXWQ","4880030.1865234375",""],
+            ['table1','node02','1','DONE','4997198327','RELOCATING','STARTED','TRUE','d63zx99jSfWjr5wUykEXWQ','4880076.4912109375',''],
+            ['table1','node01','2','DONE','4997150911','RELOCATING','STARTED','TRUE','d63zx99jSfWjr5wUykEXWQ','4880030.1865234375',''],
         ]
-        cols = [("table_name",),("node['name']",),("id",),("recovery['stage']",),("size",),("routing_state",),("state",),("primary",),("relocating_node",),("size_kb",),("partition_ident",)]
+        cols = [('table_name',),('node[\'name\']',),('id',),('recovery[\'stage\']',),('size',),('routing_state',),('state',),('primary',),('relocating_node',),('size_kb',),('partition_ident',)]
         cmd._exec.return_value = True
         cmd.cursor.fetchall.return_value = rows
         cmd.cursor.description = cols

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -35,6 +35,7 @@ from crate.crash.commands import (
     ClusterCheckCommand,
     NodeCheckCommand,
     ReadFileCommand,
+    ShardsCommand,
     ToggleAutoCapitalizeCommand,
     ToggleAutocompleteCommand,
     ToggleVerboseCommand,
@@ -266,6 +267,57 @@ class ChecksCommandTest(TestCase):
         command(cmd, 'nodes')
         cmd.logger.info.assert_called_with('NODE CHECK OK')
 
+
+class ShardsCommandTest(TestCase):
+    @patch('crate.crash.command.CrateShell')
+    def test_shards_command(self,cmd):
+        rows = [
+            ["table1","    6", "100000000","30065115537 ","1 ","      5038203304 ","  83.2423617404707 "],
+            ["table2","    6", "100000000"," 8178261348 ","0 ","               0 "," 100.0             "],
+            ["table3"," 1000", "        0","     208000 ","0 ","               0 "," 100.0             "],
+        ]
+        cols = [("table_name ", ), (" total_shards ", ), (" total_num_docs ", ), (" total_sum_shard_size ", ), (" relocating_shards ", ), (" relocating_size ", ), (" relocated_percent")]
+        cmd._exec.return_value = True
+        cmd.cursor.fetchall.return_value = rows
+        cmd.cursor.description = cols
+
+        ShardsCommand()(cmd)
+        cmd.pprint.assert_called_with(rows, [c[0] for c in cols])
+
+    @patch('crate.crash.command.CrateShell')
+    def test_shards_command_state(self,cmd):
+        rows = [
+            ["RELOCATING","2","33334465","9.307963063940406"],
+            ["STARTED","1010","166665535","26.309150873683393"],
+        ]
+        cols = [("routing_state", ), ("shard_count", ), ("num_docs", ), ("size_gb", )]
+        cmd._exec.return_value = True
+        cmd.cursor.fetchall.return_value = rows
+        cmd.cursor.description = cols
+
+        ShardsCommand()(cmd,"state")
+        cmd.pprint.assert_called_with(rows, [c[0] for c in cols])
+
+    @patch('crate.crash.command.CrateShell')
+    def test_shards_command_relocating_none(self,cmd):
+        cmd._exec.return_value = True
+        cmd.cursor.fetchall.return_value = []
+        ShardsCommand()(cmd,"relocating")
+        cmd.logger.info.assert_called_with('No shards relocating!')
+
+    @patch('crate.crash.command.CrateShell')
+    def test_shards_command_relocating(self,cmd):
+        rows = [
+            ["table1","node02","1","DONE","4997198327","RELOCATING","STARTED","TRUE","d63zx99jSfWjr5wUykEXWQ","4880076.4912109375",""],
+            ["table1","node01","2","DONE","4997150911","RELOCATING","STARTED","TRUE","d63zx99jSfWjr5wUykEXWQ","4880030.1865234375",""],
+        ]
+        cols = [("table_name",),("node['name']",),("id",),("recovery['stage']",),("size",),("routing_state",),("state",),("primary",),("relocating_node",),("size_kb",),("partition_ident",)]
+        cmd._exec.return_value = True
+        cmd.cursor.fetchall.return_value = rows
+        cmd.cursor.description = cols
+
+        ShardsCommand()(cmd,"state")
+        cmd.pprint.assert_called_with(rows, [c[0] for c in cols])
 
 @patch('crate.client.connection.Cursor', fake_cursor())
 class CommentsTest(TestCase):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -284,7 +284,21 @@ class ShardsCommandTest(TestCase):
         cmd.pprint.assert_called_with(rows, [c[0] for c in cols])
 
     @patch('crate.crash.command.CrateShell')
-    def test_shards_command_info(self,cmd):
+    def test_shards_command_overview(self,cmd):
+        rows = [
+            ['RELOCATING','FALSE','2','33334465','9.307963063940406'],
+            ['STARTED','TRUE','1010','166665535','26.309150873683393'],
+        ]
+        cols = [('state', ), ('primary',), ('shard_count', ), ('num_docs', ), ('size_gb', )]
+        cmd._exec.return_value = True
+        cmd.cursor.fetchall.return_value = rows
+        cmd.cursor.description = cols
+
+        ShardsCommand()(cmd, "overview")
+        cmd.pprint.assert_called_with(rows, [c[0] for c in cols])
+
+    @patch('crate.crash.command.CrateShell')
+    def test_shards_command_per_table(self,cmd):
         rows = [
             ['doc','table1','','1','10','1024','0','100.0'],
             ['doc','table2','','2','20','2048','1','50.0'],
@@ -295,7 +309,7 @@ class ShardsCommandTest(TestCase):
         cmd.cursor.fetchall.return_value = rows
         cmd.cursor.description = cols
 
-        ShardsCommand()(cmd, "info")
+        ShardsCommand()(cmd, "per-table")
         cmd.pprint.assert_called_with(rows, [c[0] for c in cols])
 
 
@@ -307,10 +321,10 @@ class ShardsCommandTest(TestCase):
         cmd.logger.info.assert_not_called()
 
     @patch('crate.crash.command.CrateShell')
-    def test_shards_command_info_none(self,cmd):
+    def test_shards_command_per_table_none(self,cmd):
         cmd._exec.return_value = True
         cmd.cursor.fetchall.return_value = []
-        ShardsCommand()(cmd,"info")
+        ShardsCommand()(cmd,"per-table")
         cmd.logger.info.assert_not_called()
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -329,7 +329,6 @@ class ShardsCommandTest(TestCase):
         cmd.logger.info.assert_not_called()
 
 
-@patch('crate.client.connection.Cursor', fake_cursor())
 @patch('crate.crash.command.connect', fake_connect())
 class CommentsTest(TestCase):
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -35,7 +35,6 @@ from crate.crash.commands import (
     ClusterCheckCommand,
     NodeCheckCommand,
     ReadFileCommand,
-    ShardsCommand,
     ToggleAutoCapitalizeCommand,
     ToggleAutocompleteCommand,
     ToggleVerboseCommand,
@@ -267,66 +266,6 @@ class ChecksCommandTest(TestCase):
 
         command(cmd, 'nodes')
         cmd.logger.info.assert_called_with('NODE CHECK OK')
-
-
-class ShardsCommandTest(TestCase):
-    @patch('crate.crash.command.CrateShell')
-    def test_shards_command_default(self,cmd):
-        rows = [
-            ['RELOCATING','FALSE','2','33334465','9.307963063940406'],
-            ['STARTED','TRUE','1010','166665535','26.309150873683393'],
-        ]
-        cols = [('state', ), ('primary',), ('shard_count', ), ('num_docs', ), ('size_gb', )]
-        cmd._exec.return_value = True
-        cmd.cursor.fetchall.return_value = rows
-        cmd.cursor.description = cols
-
-        ShardsCommand()(cmd)
-        cmd.pprint.assert_called_with(rows, [c[0] for c in cols])
-
-    @patch('crate.crash.command.CrateShell')
-    def test_shards_command_overview(self,cmd):
-        rows = [
-            ['RELOCATING','FALSE','2','33334465','9.307963063940406'],
-            ['STARTED','TRUE','1010','166665535','26.309150873683393'],
-        ]
-        cols = [('state', ), ('primary',), ('shard_count', ), ('num_docs', ), ('size_gb', )]
-        cmd._exec.return_value = True
-        cmd.cursor.fetchall.return_value = rows
-        cmd.cursor.description = cols
-
-        ShardsCommand()(cmd, "overview")
-        cmd.pprint.assert_called_with(rows, [c[0] for c in cols])
-
-    @patch('crate.crash.command.CrateShell')
-    def test_shards_command_per_table(self,cmd):
-        rows = [
-            ['doc','table1','','1','10','1024','0','100.0'],
-            ['doc','table2','','2','20','2048','1','50.0'],
-            ['doc','table3','','3','30','3072','2','33.3'],
-        ]
-        cols = [('schema_name',),('table_name',),('partition_ident',),('total_shards',),('total_size',),('relocating_shards',),('relocating_size',),('relocated_percent',)]
-        cmd._exec.return_value = True
-        cmd.cursor.fetchall.return_value = rows
-        cmd.cursor.description = cols
-
-        ShardsCommand()(cmd, "per-table")
-        cmd.pprint.assert_called_with(rows, [c[0] for c in cols])
-
-
-    @patch('crate.crash.command.CrateShell')
-    def test_shards_command_default_none(self,cmd):
-        cmd._exec.return_value = True
-        cmd.cursor.fetchall.return_value = []
-        ShardsCommand()(cmd)
-        cmd.logger.info.assert_not_called()
-
-    @patch('crate.crash.command.CrateShell')
-    def test_shards_command_per_table_none(self,cmd):
-        cmd._exec.return_value = True
-        cmd.cursor.fetchall.return_value = []
-        ShardsCommand()(cmd,"per-table")
-        cmd.logger.info.assert_not_called()
 
 
 @patch('crate.crash.command.connect', fake_connect())

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -876,12 +876,12 @@ class ShardsCommandEmptyDBTest(TestCase):
     def setUp(self):
         node.reset()
 
-    def test_shards_command(self):
+    def test_shards_command_output_default(self):
         expected = '\n'.join([
-            '+------------+--------------+----------------+----------------------+-------------------+-----------------+-------------------+',
-            '| table_name | total_shards | total_num_docs | total_sum_shard_size | relocating_shards | relocating_size | relocated_percent |',
-            '+------------+--------------+----------------+----------------------+-------------------+-----------------+-------------------+',
-            '+------------+--------------+----------------+----------------------+-------------------+-----------------+-------------------+\n',
+            '+-------+---------+-------------+----------+---------+',
+            '| state | primary | shard_count | num_docs | size_gb |',
+            '+-------+---------+-------------+----------+---------+',
+            '+-------+---------+-------------+----------+---------+\n',
         ])
         with CrateShell(crate_hosts=[node.http_url], is_tty=False) as cmd:
             shards_ = cmd.commands['shards']
@@ -890,42 +890,29 @@ class ShardsCommandEmptyDBTest(TestCase):
                 self.assertEqual(None, text)
                 self.assertEqual(expected, output.getvalue())
 
-    def test_shards_command_state(self):
+    def test_shards_command_output_info(self):
         expected = '\n'.join([
-            '+---------------+-------------+----------+---------+',
-            '| routing_state | shard_count | num_docs | size_gb |',
-            '+---------------+-------------+----------+---------+',
-            '+---------------+-------------+----------+---------+\n',
+            '+-------------+------------+-----------------+--------------+------------+-------------------+-----------------+-------------------+',
+            '| schema_name | table_name | partition_ident | total_shards | total_size | relocating_shards | relocating_size | relocated_percent |',
+            '+-------------+------------+-----------------+--------------+------------+-------------------+-----------------+-------------------+',
+            '+-------------+------------+-----------------+--------------+------------+-------------------+-----------------+-------------------+\n',
         ])
         with CrateShell(crate_hosts=[node.http_url], is_tty=False) as cmd:
             shards_ = cmd.commands['shards']
             with patch('sys.stdout', new_callable=StringIO) as output:
-                text = shards_(cmd, 'state')
+                text = shards_(cmd, 'info')
                 self.assertEqual(None, text)
                 self.assertEqual(expected, output.getvalue())
 
-    def test_shards_command_relocating(self):
-        expected = '\n'.join([
-            '+------------+--------------+----+-------------------+------+---------------+-------+---------+-----------------+---------+-----------------+',
-            "| table_name | node['name'] | id | recovery['stage'] | size | routing_state | state | primary | relocating_node | size_kb | partition_ident |",
-            '+------------+--------------+----+-------------------+------+---------------+-------+---------+-----------------+---------+-----------------+',
-            '+------------+--------------+----+-------------------+------+---------------+-------+---------+-----------------+---------+-----------------+\n',
-        ])
-        with CrateShell(crate_hosts=[node.http_url], is_tty=False) as cmd:
-            shards_ = cmd.commands['shards']
-            with patch('sys.stdout', new_callable=StringIO) as output:
-                text = shards_(cmd, 'relocating')
-                self.assertEqual(None, text)
-                self.assertEqual(expected, output.getvalue())
 
-    def test_shards_command_wrong_argument(self):
+    def test_shards_command_output_wrong_argument(self):
         with CrateShell(crate_hosts=[node.http_url], is_tty=False) as cmd:
             shards_ = cmd.commands['shards']
             with patch('sys.stdout', new_callable=StringIO) as output:
                 cmd.logger = ColorPrinter(False, stream=output)
                 text = shards_(cmd, 'arg1', 'arg2')
                 self.assertEqual(None, text)
-                self.assertEqual('Command argument not supported (available options: `state`, `relocating`).\n', output.getvalue())
+                self.assertEqual('Command argument not supported (available options: `info`).\n', output.getvalue())
 
 
 
@@ -939,48 +926,41 @@ class ShardsCommandWithContentTest(TestCase):
         with CrateShell(crate_hosts=[node.http_url], is_tty=False) as cmd:
             cmd.process('CREATE TABLE test_table (id INTEGER PRIMARY KEY, data STRING ) CLUSTERED INTO 10 SHARDS WITH (number_of_replicas = 0);\n')
 
-    def test_shards_command(self):
-        expected = '\n'.join([
-            '+------------+--------------+----------------+----------------------+-------------------+-----------------+-------------------+',
-            '| table_name | total_shards | total_num_docs | total_sum_shard_size | relocating_shards | relocating_size | relocated_percent |',
-            '+------------+--------------+----------------+----------------------+-------------------+-----------------+-------------------+',
-            '| test_table |           10 |              0 |                dummy |                 0 |               0 |             100.0 |',
-            '+------------+--------------+----------------+----------------------+-------------------+-----------------+-------------------+\n',
-        ])
+    def test_shards_command_output_default(self):
+        expected = [
+            '+---------+---------+-------------+-----------+---------------------+',
+            '| state   | primary | shard_count |  num_docs |             size_gb |',
+            '+---------+---------+-------------+-----------+---------------------+',
+            '| STARTED | FALSEy  |          ?6 | 1x0000000 |  7. DUMMY VALUE 614 |',
+            '+---------+---------+-------------+-----------+---------------------+\n',
+        ]
         with CrateShell(crate_hosts=[node.http_url], is_tty=False) as cmd:
             shards_ = cmd.commands['shards']
             with patch('sys.stdout', new_callable=StringIO) as output:
                 text = shards_(cmd)
                 self.assertEqual(None, text)
-                self.assertEqual(len(expected.splitlines()), len(output.getvalue().splitlines()))
+                output_lines = output.getvalue().splitlines()
+                self.assertEqual(len(expected), len(output_lines))
+                header = lambda x: [word.strip() for word in x[1].split('|')]
+                self.assertEqual(header(expected), header(output_lines))
 
-    def test_shards_command_state(self):
-        expected = '\n'.join([
-            '+---------------+-------------+----------+-----------------------+',
-            '| routing_state | shard_count | num_docs |               size_gb |',
-            '+---------------+-------------+----------+-----------------------+',
-            '| STARTED       |          10 |        0 | 7.40AAAAAAAAAAAAAA-07 |',
-            '+---------------+-------------+----------+-----------------------+\n'
-        ])
+
+    def test_shards_command_ouput_info(self):
+        expected = [
+            '+-------------+------------+-----------------+--------------+------------+-------------------+-----------------+-------------------+',
+            '| schema_name | table_name | partition_ident | total_shards | total_size | relocating_shards | relocating_size | relocated_percent |',
+            '+-------------+------------+-----------------+--------------+------------+-------------------+-----------------+-------------------+',
+            '| doc         | test_table |                 |           10 |        624 |                 0 | NULL            |             100.0 |',
+            '+-------------+------------+-----------------+--------------+------------+-------------------+-----------------+-------------------+\n',
+        ]
         with CrateShell(crate_hosts=[node.http_url], is_tty=False) as cmd:
             shards_ = cmd.commands['shards']
             with patch('sys.stdout', new_callable=StringIO) as output:
-                text = shards_(cmd, 'state')
+                text = shards_(cmd, 'info')
                 self.assertEqual(None, text)
-                self.assertEqual(len(expected.splitlines()), len(output.getvalue().splitlines()))
-
-    def test_shards_command_relocating(self):
-        expected = '\n'.join([
-            '+------------+--------------+----+-------------------+------+---------------+-------+---------+-----------------+---------+-----------------+',
-            "| table_name | node['name'] | id | recovery['stage'] | size | routing_state | state | primary | relocating_node | size_kb | partition_ident |",
-            '+------------+--------------+----+-------------------+------+---------------+-------+---------+-----------------+---------+-----------------+',
-            '+------------+--------------+----+-------------------+------+---------------+-------+---------+-----------------+---------+-----------------+\n',
-        ])
-        with CrateShell(crate_hosts=[node.http_url], is_tty=False) as cmd:
-            shards_ = cmd.commands['shards']
-            with patch('sys.stdout', new_callable=StringIO) as output:
-                text = shards_(cmd, 'relocating')
-                self.assertEqual(None, text)
-                self.assertEqual(expected, output.getvalue())
+                output_lines = output.getvalue().splitlines()
+                self.assertEqual(len(expected), len(output_lines))
+                header = lambda x: [word.strip() for word in x[1].split('|')]
+                self.assertEqual(header(expected), header(output_lines))
 
 setup_logging(level=logging.INFO)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -653,9 +653,11 @@ class CommandTest(TestCase):
             '\\pager                          set an external pager. Use without argument to reset to internal paging',
             '\\q                              quit crash',
             '\\r                              read and execute statements from a file',
+            '\\shards                         short summary for shards and their relocation (use `all` as argument for longer output)',
             '\\sysinfo                        print system and cluster info',
             '\\verbose                        toggle verbose mode',
         ])
+
 
         help_ = command.commands['?']
         self.assertTrue(isinstance(help_, Command))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -653,7 +653,7 @@ class CommandTest(TestCase):
             '\\pager                          set an external pager. Use without argument to reset to internal paging',
             '\\q                              quit crash',
             '\\r                              read and execute statements from a file',
-            '\\shards                         short summary for shards and their relocation (use `all` as argument for longer output)',
+            '\\shards                         shows progress of shards relocation (optional arguments: `state` and `relocating`)',
             '\\sysinfo                        print system and cluster info',
             '\\verbose                        toggle verbose mode',
         ])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -872,4 +872,115 @@ class CommandTest(TestCase):
             self.assertEqual(crash.connect_info.schema, None)
 
 
+class ShardsCommandEmptyDBTest(TestCase):
+    def setUp(self):
+        node.reset()
+
+    def test_shards_command(self):
+        expected = '\n'.join([
+            '+------------+--------------+----------------+----------------------+-------------------+-----------------+-------------------+',
+            '| table_name | total_shards | total_num_docs | total_sum_shard_size | relocating_shards | relocating_size | relocated_percent |',
+            '+------------+--------------+----------------+----------------------+-------------------+-----------------+-------------------+',
+            '+------------+--------------+----------------+----------------------+-------------------+-----------------+-------------------+\n',
+        ])
+        with CrateShell(crate_hosts=[node.http_url], is_tty=False) as cmd:
+            shards_ = cmd.commands['shards']
+            with patch('sys.stdout', new_callable=StringIO) as output:
+                text = shards_(cmd)
+                self.assertEqual(None, text)
+                self.assertEqual(expected, output.getvalue())
+
+    def test_shards_command_state(self):
+        expected = '\n'.join([
+            '+---------------+-------------+----------+---------+',
+            '| routing_state | shard_count | num_docs | size_gb |',
+            '+---------------+-------------+----------+---------+',
+            '+---------------+-------------+----------+---------+\n',
+        ])
+        with CrateShell(crate_hosts=[node.http_url], is_tty=False) as cmd:
+            shards_ = cmd.commands['shards']
+            with patch('sys.stdout', new_callable=StringIO) as output:
+                text = shards_(cmd, 'state')
+                self.assertEqual(None, text)
+                self.assertEqual(expected, output.getvalue())
+
+    def test_shards_command_relocating(self):
+        expected = '\n'.join([
+            '+------------+--------------+----+-------------------+------+---------------+-------+---------+-----------------+---------+-----------------+',
+            "| table_name | node['name'] | id | recovery['stage'] | size | routing_state | state | primary | relocating_node | size_kb | partition_ident |",
+            '+------------+--------------+----+-------------------+------+---------------+-------+---------+-----------------+---------+-----------------+',
+            '+------------+--------------+----+-------------------+------+---------------+-------+---------+-----------------+---------+-----------------+\n',
+        ])
+        with CrateShell(crate_hosts=[node.http_url], is_tty=False) as cmd:
+            shards_ = cmd.commands['shards']
+            with patch('sys.stdout', new_callable=StringIO) as output:
+                text = shards_(cmd, 'relocating')
+                self.assertEqual(None, text)
+                self.assertEqual(expected, output.getvalue())
+
+    def test_shards_command_wrong_argument(self):
+        with CrateShell(crate_hosts=[node.http_url], is_tty=False) as cmd:
+            shards_ = cmd.commands['shards']
+            with patch('sys.stdout', new_callable=StringIO) as output:
+                cmd.logger = ColorPrinter(False, stream=output)
+                text = shards_(cmd, 'arg1', 'arg2')
+                self.assertEqual(None, text)
+                self.assertEqual('Command argument not supported (available options: `state`, `relocating`).\n', output.getvalue())
+
+
+
+class ShardsCommandWithContentTest(TestCase):
+    def tearDown(self):
+        with CrateShell(crate_hosts=[node.http_url], is_tty=False) as cmd:
+            cmd.process('DROP TABLE IF EXISTS test_table;')
+
+    def setUp(self):
+        node.reset()
+        with CrateShell(crate_hosts=[node.http_url], is_tty=False) as cmd:
+            cmd.process('CREATE TABLE test_table (id INTEGER PRIMARY KEY, data STRING ) CLUSTERED INTO 10 SHARDS WITH (number_of_replicas = 0);\n')
+
+    def test_shards_command(self):
+        expected = '\n'.join([
+            '+------------+--------------+----------------+----------------------+-------------------+-----------------+-------------------+',
+            '| table_name | total_shards | total_num_docs | total_sum_shard_size | relocating_shards | relocating_size | relocated_percent |',
+            '+------------+--------------+----------------+----------------------+-------------------+-----------------+-------------------+',
+            '| test_table |           10 |              0 |                dummy |                 0 |               0 |             100.0 |',
+            '+------------+--------------+----------------+----------------------+-------------------+-----------------+-------------------+\n',
+        ])
+        with CrateShell(crate_hosts=[node.http_url], is_tty=False) as cmd:
+            shards_ = cmd.commands['shards']
+            with patch('sys.stdout', new_callable=StringIO) as output:
+                text = shards_(cmd)
+                self.assertEqual(None, text)
+                self.assertEqual(len(expected.splitlines()), len(output.getvalue().splitlines()))
+
+    def test_shards_command_state(self):
+        expected = '\n'.join([
+            '+---------------+-------------+----------+-----------------------+',
+            '| routing_state | shard_count | num_docs |               size_gb |',
+            '+---------------+-------------+----------+-----------------------+',
+            '| STARTED       |          10 |        0 | 7.40AAAAAAAAAAAAAA-07 |',
+            '+---------------+-------------+----------+-----------------------+\n'
+        ])
+        with CrateShell(crate_hosts=[node.http_url], is_tty=False) as cmd:
+            shards_ = cmd.commands['shards']
+            with patch('sys.stdout', new_callable=StringIO) as output:
+                text = shards_(cmd, 'state')
+                self.assertEqual(None, text)
+                self.assertEqual(len(expected.splitlines()), len(output.getvalue().splitlines()))
+
+    def test_shards_command_relocating(self):
+        expected = '\n'.join([
+            '+------------+--------------+----+-------------------+------+---------------+-------+---------+-----------------+---------+-----------------+',
+            "| table_name | node['name'] | id | recovery['stage'] | size | routing_state | state | primary | relocating_node | size_kb | partition_ident |",
+            '+------------+--------------+----+-------------------+------+---------------+-------+---------+-----------------+---------+-----------------+',
+            '+------------+--------------+----+-------------------+------+---------------+-------+---------+-----------------+---------+-----------------+\n',
+        ])
+        with CrateShell(crate_hosts=[node.http_url], is_tty=False) as cmd:
+            shards_ = cmd.commands['shards']
+            with patch('sys.stdout', new_callable=StringIO) as output:
+                text = shards_(cmd, 'relocating')
+                self.assertEqual(None, text)
+                self.assertEqual(expected, output.getvalue())
+
 setup_logging(level=logging.INFO)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -653,7 +653,7 @@ class CommandTest(TestCase):
             '\\pager                          set an external pager. Use without argument to reset to internal paging',
             '\\q                              quit crash',
             '\\r                              read and execute statements from a file',
-            '\\shards                         shows progress of shards relocation (optional arguments: `state` and `relocating`)',
+            '\\shards                         shows shards state, optionally per table, e.g. \\shards info',
             '\\sysinfo                        print system and cluster info',
             '\\verbose                        toggle verbose mode',
         ])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -945,7 +945,7 @@ class ShardsCommandWithContentTest(TestCase):
                 self.assertEqual(header(expected), header(output_lines))
 
 
-    def test_shards_command_ouput_info(self):
+    def test_shards_command_output_info(self):
         expected = [
             '+-------------+------------+-----------------+--------------+------------+-------------------+-----------------+-------------------+',
             '| schema_name | table_name | partition_ident | total_shards | total_size | relocating_shards | relocating_size | relocated_percent |',

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -890,7 +890,21 @@ class ShardsCommandEmptyDBTest(TestCase):
                 self.assertEqual(None, text)
                 self.assertEqual(expected, output.getvalue())
 
-    def test_shards_command_output_info(self):
+    def test_shards_command_output_overview(self):
+        expected = '\n'.join([
+            '+-------+---------+-------------+----------+---------+',
+            '| state | primary | shard_count | num_docs | size_gb |',
+            '+-------+---------+-------------+----------+---------+',
+            '+-------+---------+-------------+----------+---------+\n',
+        ])
+        with CrateShell(crate_hosts=[node.http_url], is_tty=False) as cmd:
+            shards_ = cmd.commands['shards']
+            with patch('sys.stdout', new_callable=StringIO) as output:
+                text = shards_(cmd, "overview")
+                self.assertEqual(None, text)
+                self.assertEqual(expected, output.getvalue())
+
+    def test_shards_command_output_per_table(self):
         expected = '\n'.join([
             '+-------------+------------+-----------------+--------------+------------+-------------------+-----------------+-------------------+',
             '| schema_name | table_name | partition_ident | total_shards | total_size | relocating_shards | relocating_size | relocated_percent |',
@@ -900,7 +914,7 @@ class ShardsCommandEmptyDBTest(TestCase):
         with CrateShell(crate_hosts=[node.http_url], is_tty=False) as cmd:
             shards_ = cmd.commands['shards']
             with patch('sys.stdout', new_callable=StringIO) as output:
-                text = shards_(cmd, 'info')
+                text = shards_(cmd, 'per-table')
                 self.assertEqual(None, text)
                 self.assertEqual(expected, output.getvalue())
 
@@ -912,7 +926,7 @@ class ShardsCommandEmptyDBTest(TestCase):
                 cmd.logger = ColorPrinter(False, stream=output)
                 text = shards_(cmd, 'arg1', 'arg2')
                 self.assertEqual(None, text)
-                self.assertEqual('Command argument not supported (available options: `info`).\n', output.getvalue())
+                self.assertEqual('Command argument not supported (available options: `overview`, `per-table`).\n', output.getvalue())
 
 
 
@@ -945,7 +959,7 @@ class ShardsCommandWithContentTest(TestCase):
                 self.assertEqual(header(expected), header(output_lines))
 
 
-    def test_shards_command_output_info(self):
+    def test_shards_command_output_per_table(self):
         expected = [
             '+-------------+------------+-----------------+--------------+------------+-------------------+-----------------+-------------------+',
             '| schema_name | table_name | partition_ident | total_shards | total_size | relocating_shards | relocating_size | relocated_percent |',
@@ -956,7 +970,7 @@ class ShardsCommandWithContentTest(TestCase):
         with CrateShell(crate_hosts=[node.http_url], is_tty=False) as cmd:
             shards_ = cmd.commands['shards']
             with patch('sys.stdout', new_callable=StringIO) as output:
-                text = shards_(cmd, 'info')
+                text = shards_(cmd, 'per-table')
                 self.assertEqual(None, text)
                 output_lines = output.getvalue().splitlines()
                 self.assertEqual(len(expected), len(output_lines))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -940,32 +940,25 @@ class ShardsCommandWithContentTest(TestCase):
         with CrateShell(crate_hosts=[node.http_url], is_tty=False) as cmd:
             cmd.process('CREATE TABLE test_table (id INTEGER PRIMARY KEY, data STRING ) CLUSTERED INTO 10 SHARDS WITH (number_of_replicas = 0);\n')
 
+    # the line count: 3 borders, 1 header and 1 aggregated row.
+    EXPECTED_LINES = 5
+
     def test_shards_command_output_default(self):
-        expected = [
-            '+---------+---------+-------------+-----------+---------------------+',
-            '| state   | primary | shard_count |  num_docs |             size_gb |',
-            '+---------+---------+-------------+-----------+---------------------+',
-            '| STARTED | FALSEy  |          ?6 | 1x0000000 |  7. DUMMY VALUE 614 |',
-            '+---------+---------+-------------+-----------+---------------------+\n',
-        ]
+        expected_columns = ['state', 'primary', 'shard_count', 'num_docs', 'size_gb']
         with CrateShell(crate_hosts=[node.http_url], is_tty=False) as cmd:
             shards_ = cmd.commands['shards']
             with patch('sys.stdout', new_callable=StringIO) as output:
                 text = shards_(cmd)
                 self.assertEqual(None, text)
                 output_lines = output.getvalue().splitlines()
-                self.assertEqual(len(expected), len(output_lines))
-                header = lambda x: [word.strip() for word in x[1].split('|')]
-                self.assertEqual(header(expected), header(output_lines))
-
+                self.assertEqual(self.EXPECTED_LINES, len(output_lines))
+                columns = [word.strip() for word in output_lines[1].strip('|').split('|')]
+                self.assertEqual(expected_columns, columns)
 
     def test_shards_command_output_per_table(self):
-        expected = [
-            '+-------------+------------+-----------------+--------------+------------+-------------------+-----------------+-------------------+',
-            '| schema_name | table_name | partition_ident | total_shards | total_size | relocating_shards | relocating_size | relocated_percent |',
-            '+-------------+------------+-----------------+--------------+------------+-------------------+-----------------+-------------------+',
-            '| doc         | test_table |                 |           10 |        624 |                 0 | NULL            |             100.0 |',
-            '+-------------+------------+-----------------+--------------+------------+-------------------+-----------------+-------------------+\n',
+        expected_columns = [
+            'schema_name', 'table_name', 'partition_ident', 'total_shards',
+            'total_size', 'relocating_shards', 'relocating_size', 'relocated_percent',
         ]
         with CrateShell(crate_hosts=[node.http_url], is_tty=False) as cmd:
             shards_ = cmd.commands['shards']
@@ -973,8 +966,8 @@ class ShardsCommandWithContentTest(TestCase):
                 text = shards_(cmd, 'per-table')
                 self.assertEqual(None, text)
                 output_lines = output.getvalue().splitlines()
-                self.assertEqual(len(expected), len(output_lines))
-                header = lambda x: [word.strip() for word in x[1].split('|')]
-                self.assertEqual(header(expected), header(output_lines))
+                self.assertEqual(self.EXPECTED_LINES, len(output_lines))
+                columns = [word.strip() for word in output_lines[1].strip('|').split('|')]
+                self.assertEqual(expected_columns, columns)
 
 setup_logging(level=logging.INFO)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -653,7 +653,7 @@ class CommandTest(TestCase):
             '\\pager                          set an external pager. Use without argument to reset to internal paging',
             '\\q                              quit crash',
             '\\r                              read and execute statements from a file',
-            '\\shards                         shows shards state, optionally per table, e.g. \\shards info',
+            '\\shards                         shows shards overview, optionally per table, e.g. \\shards info',
             '\\sysinfo                        print system and cluster info',
             '\\verbose                        toggle verbose mode',
         ])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -653,7 +653,7 @@ class CommandTest(TestCase):
             '\\pager                          set an external pager. Use without argument to reset to internal paging',
             '\\q                              quit crash',
             '\\r                              read and execute statements from a file',
-            '\\shards                         shows shards overview, optionally per table, e.g. \\shards info',
+            '\\shards                         shows shards overview, optionally per table, e.g. \\shards per-table',
             '\\sysinfo                        print system and cluster info',
             '\\verbose                        toggle verbose mode',
         ])


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

As requested in #493  this PR aims adds a new command `\shards` to conveniently query for shards undergoing relocation. It computes the the aggregated progress per table based on the sum of the sizes of relocating shards divided by the total size of the table shards.

Optionally, `state` and `relocating` can be provided as an argument to respectively:
 - get a short summary of shards aggregated by state
 - view details of which ones are currently relocating
 
## Integration testing
I resorted to `docker compose` and scripting to move shards withing a cluster in order to test the what's implemented here. In order integrate that type of testing it in this code base, I spent sometime looking at `cratedb_toolkit.testing.testcontainers.cratedb` but I believe it would require another PR. For now, I resort to single-node integration testing.


## Checklist
 - [x] Fixes https://github.com/crate/crash/issues/493
 - [x] Unit testing
 - [x] Integration testing
 - [x] Command docs
 - [x] Update `CHANGES.txt`