### PR TITLE
fix: handle statements with only semicolons/whitespace

### DIFF
--- a/src/crate/crash/command.py
+++ b/src/crate/crash/command.py
@@ -276,6 +276,11 @@ class CrateShell:
     def _process_sql(self, text):
         sql = sqlparse.format(text, strip_comments=False)
         for statement in sqlparse.parse(sql):
+            # Skip statements that contain no actual SQL (e.g. an input
+            # consisting only of ';' or whitespace), which would otherwise
+            # crash stmt_type with IndexError.
+            if not str(statement).strip(' \t\n\r;'):
+                continue
             self._exec_and_print(statement)
 
     def exit(self):
@@ -515,8 +520,10 @@ def stmt_type(expression: Union[str, sqlparse.sql.Statement]):
     """Extract type of statement, e.g. SELECT, INSERT, UPDATE, DELETE, ..."""
     statement = to_statement(expression)
     command_with_args = str(statement.token_first(skip_ws=True, skip_cm=True))
-    effective_command = re.findall(r'[\w]+', command_with_args)[0]
-    return effective_command.upper()
+    words = re.findall(r'[\w]+', command_with_args)
+    if not words:
+        return ''
+    return words[0].upper()
 
 
 def to_statement(expression: Union[str, sqlparse.sql.Statement]) -> sqlparse.sql.Statement:

--- a/src/crate/crash/command.py
+++ b/src/crate/crash/command.py
@@ -276,9 +276,6 @@ class CrateShell:
     def _process_sql(self, text):
         sql = sqlparse.format(text, strip_comments=False)
         for statement in sqlparse.parse(sql):
-            # Skip statements that contain no actual SQL (e.g. an input
-            # consisting only of ';' or whitespace), which would otherwise
-            # crash stmt_type with IndexError.
             if not str(statement).strip(' \t\n\r;'):
                 continue
             self._exec_and_print(statement)

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -121,6 +121,12 @@ class CommandUtilsTest(TestCase):
         # statements with arguments as part of the command
         self.assertEqual(stmt_type('/* foo */ DENY DQL, DML, DDL, AL ON SCHEMA sys TO test;'), 'DENY')
 
+    def test_stmt_type_punctuation_only_does_not_crash(self):
+        # Statements that contain no word characters should not crash with
+        # IndexError; see issue #499.
+        self.assertEqual(stmt_type(';'), '')
+        self.assertEqual(stmt_type(';;'), '')
+
     def test_decode_timeout_success(self):
         self.assertEqual(_decode_timeout(None), None)
         self.assertEqual(_decode_timeout(-1), None)

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -122,8 +122,6 @@ class CommandUtilsTest(TestCase):
         self.assertEqual(stmt_type('/* foo */ DENY DQL, DML, DDL, AL ON SCHEMA sys TO test;'), 'DENY')
 
     def test_stmt_type_punctuation_only_does_not_crash(self):
-        # Statements that contain no word characters should not crash with
-        # IndexError; see issue #499.
         self.assertEqual(stmt_type(';'), '')
         self.assertEqual(stmt_type(';;'), '')
 


### PR DESCRIPTION
Fixes #499.

Entering `;` at the crash prompt crashed with `IndexError: list index out of range`. The first token of the parsed statement is a Punctuation, and `re.findall(r'[\w]+', ';')[0]` indexes an empty list. Skip empty statements in `_process_sql` and harden `stmt_type` to return `''` when the statement has no word tokens. Regression test added in `CommandUtilsTest.test_stmt_type_punctuation_only_does_not_crash`.