### PR TITLE
Ignore statements containing only semicolons or whitespace

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for crash
 Unreleased
 ==========
 
+- Fixed an ``IndexError`` crash when submitting a statement that contains only
+  semicolons, whitespace or comments. Such statements are now ignored.
+
 2026/02/09 0.32.0
 =================
 

--- a/src/crate/crash/command.py
+++ b/src/crate/crash/command.py
@@ -276,6 +276,12 @@ class CrateShell:
     def _process_sql(self, text):
         sql = sqlparse.format(text, strip_comments=False)
         for statement in sqlparse.parse(sql):
+            # Skip statements that contain no actual SQL, e.g. a line with
+            # only whitespace, semicolons or comments. Executing those would
+            # raise an IndexError in stmt_type().
+            if not re.search(r'\w', sqlparse.format(str(statement),
+                                                    strip_comments=True)):
+                continue
             self._exec_and_print(statement)
 
     def exit(self):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -398,6 +398,26 @@ class MultipleStatementsTest(TestCase):
             call("SELECT\n1\nWHERE\n2\n=\n3\n;"),
         ])
 
+    def test_statement_with_only_semicolons(self):
+        """A line with only semicolons or whitespace is ignored, not executed."""
+
+        cmd = CrateShell()
+        cmd._exec = Mock()
+        cmd.process(";")
+        cmd.process(";;\n;")
+        cmd.process("   \n\t")
+        self.assertListEqual(cmd._exec.mock_calls, [])
+
+    def test_statement_with_only_comments(self):
+        """A statement that is only comments is ignored, not executed."""
+
+        cmd = CrateShell()
+        cmd._exec = Mock()
+        cmd.process("-- just a comment")
+        cmd.process("-- line one\n-- line two")
+        cmd.process("/* block\n   comment\n   spanning lines */")
+        self.assertListEqual(cmd._exec.mock_calls, [])
+
     def test_multiple_commands_no_sql(self):
         cmd = CrateShell()
         cmd._try_exec_cmd = MagicMock()


### PR DESCRIPTION
Fixes #499.

Submitting a statement that contains only `;` (or only whitespace/comments) crashed crash with `IndexError: list index out of range` from `stmt_type()`, since `re.findall(r'[\w]+', ...)` returns an empty list.

`_process_sql` now skips statements that have no word characters after stripping comments, so an empty line is written instead of crashing.

Added a regression test in `MultipleStatementsTest`.