### PR TITLE
Add support for https:// and http:// when connecting to CrateDB instances

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,7 @@ Unreleased
 
 - Fixed an ``IndexError`` crash when submitting a statement that contains only
   semicolons, whitespace or comments. Such statements are now ignored.
+- Added support for ``https://`` and ``http://`` when connecting to CrateDB.
 
 2026/02/09 0.32.0
 =================

--- a/src/crate/crash/command.py
+++ b/src/crate/crash/command.py
@@ -555,19 +555,36 @@ def get_lines_from_stdin():
 def host_and_port(host_or_port):
     """
     Return full hostname/IP + port, possible input formats are:
-      * host:port  -> host:port
-      * :          -> localhost:4200
-      * :port      -> localhost:port
-      * host       -> host:4200
+      * host:port         -> host:port
+      * :                 -> localhost:4200
+      * :port             -> localhost:port
+      * host              -> host:4200
+      * https://host:port -> host:port
+      * http://host:port  -> host:port
+      * https://          -> localhost:4200
+      * http://           -> localhost:4200
     """
-    if ':' in host_or_port:
-        if len(host_or_port) == 1:
-            return 'localhost:4200'
-        elif host_or_port.startswith(':'):
-            return 'localhost' + host_or_port
-        return host_or_port
-    return host_or_port + ':4200'
-
+    if host_or_port == '':
+        raise ValueError("Invalid host:port format")
+    if host_or_port.startswith('https://'):
+        host_or_port = host_or_port[8:]
+    elif host_or_port.startswith('http://'):
+        host_or_port = host_or_port[7:]
+    if host_or_port == '':
+        host = 'localhost'
+        port = '4200'
+    elif host_or_port == ':':
+        host = 'localhost'
+        port = '4200'
+    elif host_or_port.startswith(':'):
+        host = 'localhost'
+        port = host_or_port[1:]
+    elif ':' in host_or_port:
+        host, port = host_or_port.split(':', 1)
+    else:
+        host = host_or_port
+        port = '4200'
+    return host + ':' + port
 
 def get_information_schema_query(lowest_server_version):
     schema_name = \

--- a/src/crate/crash/command.py
+++ b/src/crate/crash/command.py
@@ -586,6 +586,7 @@ def host_and_port(host_or_port):
         port = '4200'
     return host + ':' + port
 
+
 def get_information_schema_query(lowest_server_version):
     schema_name = \
         "table_schema" if lowest_server_version >= \

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -101,6 +101,11 @@ class CommandLineArgumentsTest(TestCase):
         # neither host nor port are provided
         # default host and default port are used
         self.assertEqual(host_and_port(':'), 'localhost:4200')
+        # using https
+        self.assertEqual(host_and_port('https://localhost:4321'), 'localhost:4321')
+        self.assertEqual(host_and_port('https://localhost'), 'localhost:4200')
+        self.assertEqual(host_and_port('https://:4000'), 'localhost:4000')
+        self.assertEqual(host_and_port('https://:'), 'localhost:4200')
 
 
 class CommandUtilsTest(TestCase):


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

It is possible to connect to CrateDB using over HTTP(S). Some users might prefix hostname and port with `https://` or `http://`, and while it is strictly is needed, adding support for it, will make `crash` less frictional to use.

## Checklist

 - [x] Link to issue this PR refers to (if applicable): Fixes #440 
