### PR TITLE
Mock the connection 

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -39,7 +39,7 @@ from crate.crash.commands import (
     ToggleAutocompleteCommand,
     ToggleVerboseCommand,
 )
-from tests.util import fake_cursor
+from tests.util import fake_connect
 
 
 class ReadFileCommandTest(TestCase):
@@ -130,6 +130,7 @@ class ToggleVerboseCommandTest(TestCase):
         self.assertEqual(fake_cmd.reconnect.call_count, 1)
 
 
+@patch('crate.crash.command.connect', fake_connect())
 class ShowTablesCommandTest(TestCase):
 
     def test_post_2_0(self):
@@ -267,7 +268,7 @@ class ChecksCommandTest(TestCase):
         cmd.logger.info.assert_called_with('NODE CHECK OK')
 
 
-@patch('crate.client.connection.Cursor', fake_cursor())
+@patch('crate.crash.command.connect', fake_connect())
 class CommentsTest(TestCase):
 
     def test_sql_comments(self):
@@ -364,7 +365,7 @@ comment */ 4;
         self.assertIn("SELECT 1 row in set", cmd.logger.info.call_args[0][0])
 
 
-@patch('crate.client.connection.Cursor', fake_cursor())
+@patch('crate.crash.command.connect', fake_connect())
 class MultipleStatementsTest(TestCase):
 
     def test_single_line_multiple_sql_statements(self):

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -19,6 +19,7 @@
 
 import re
 from unittest import TestCase
+from unittest.mock import patch
 
 from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.document import Document
@@ -31,12 +32,14 @@ from crate.crash.repl import (
     _get_toolbar_tokens,
     create_buffer,
 )
+from tests.util import fake_connect
 
 
 class SQLCompleterTest(TestCase):
 
     def setUp(self):
-        cmd = CrateShell()
+        with patch('crate.crash.command.connect', fake_connect()):
+            cmd = CrateShell()
         self.completer = SQLCompleter(cmd)
 
     def test_get_builtin_command_completions(self):
@@ -48,6 +51,7 @@ class SQLCompleterTest(TestCase):
         self.assertEqual(result, ['dynamic'])
 
 
+@patch('crate.crash.command.connect', fake_connect())
 class CrashBufferTest(TestCase):
 
     def test_create_buffer(self):
@@ -59,7 +63,8 @@ class CrashBufferTest(TestCase):
 class AutoCapitalizeTest(TestCase):
 
     def setUp(self):
-        cmd = CrateShell()
+        with patch('crate.crash.command.connect', fake_connect()):
+            cmd = CrateShell()
         self.capitalizer = Capitalizer(cmd, SQLCompleter(cmd))
 
     def test_capitalize(self):

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,6 +1,9 @@
 from unittest.mock import Mock
 
+from verlib2 import Version
+
 from crate.client.cursor import Cursor
+from crate.client.exceptions import ConnectionError
 
 
 def mocked_cursor(description, records, duration=0.1):
@@ -21,3 +24,26 @@ def fake_cursor():
     that just works if you do not care about results.
     """
     return mocked_cursor(description=[('undef',)], records=[('undef', None)])
+
+
+def fake_connect():
+    """
+    Provide a mocked replacement for `crate.crash.command.connect`, so that
+    instantiating a `CrateShell` in unit tests never opens real network
+    connections to `localhost:4200`.
+
+    The mock behaves like a connection to an unreachable server: the reported
+    server version 0.0.0 makes `CrateShell.is_conn_available()` return False,
+    and `cursor.execute()` raises `ConnectionError`. Tests that need a
+    specific version set `cmd.connection.lowest_server_version` themselves;
+    each `connect()` call yields a fresh connection, so such changes do not
+    leak between tests.
+    """
+    def make_connection(*args, **kwargs):
+        cursor = fake_cursor()()
+        cursor.execute.side_effect = ConnectionError('mocked connection: no server available')
+        connection = Mock(name='fake_connection')
+        connection.lowest_server_version = Version('0.0.0')
+        connection.cursor.return_value = cursor
+        return connection
+    return Mock(name='fake_connect', side_effect=make_connection)


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Mock the connection instead of the cursor to avoid trying to connect to non-existing server

## Checklist

 - [x] Link to issue this PR refers to (if applicable): Fixes #508 
