### PR TITLE
Fix interactive stall when a statement ends with a trailing comment

### DIFF
--- a/src/crate/crash/repl.py
+++ b/src/crate/crash/repl.py
@@ -22,6 +22,7 @@
 
 import os
 import re
+import sqlparse
 from getpass import getpass
 
 from prompt_toolkit import Application
@@ -199,7 +200,12 @@ class CrashBuffer(Buffer):
                 return False
             if doc.text.startswith('\\'):
                 return False
-            return not doc.text.rstrip().endswith(';')
+            # A trailing comment must not keep the buffer in multiline mode,
+            # otherwise e.g. "select 42; -- foo" can never be submitted (#496).
+            # sqlparse is syntax-aware, so a ";" inside a string literal or a
+            # "--" that is part of a literal is left untouched.
+            sql = sqlparse.format(doc.text, strip_comments=True)
+            return not sql.rstrip().endswith(';')
 
         super().__init__(*args, multiline=is_multiline, **kwargs)
 

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -59,6 +59,23 @@ class CrashBufferTest(TestCase):
         buffer = create_buffer(cmd, '/tmp/history')
         self.assertEqual(buffer.on_text_insert.fire(), None)
 
+    def _multiline(self, text):
+        cmd = CrateShell()
+        buffer = create_buffer(cmd, '/tmp/history')
+        buffer.document = Document(text)
+        return buffer.multiline()
+
+    def test_statement_with_trailing_comment_is_not_multiline(self):
+        # regression for #496: "select 42; -- foo" used to keep the
+        # buffer in multiline mode forever, stalling the interactive session
+        self.assertFalse(self._multiline('select 42; -- foo'))
+
+    def test_statement_without_semicolon_is_still_multiline(self):
+        self.assertTrue(self._multiline('select 42'))
+
+    def test_semicolon_inside_string_literal_is_still_multiline(self):
+        self.assertTrue(self._multiline("select ';'"))
+
 
 class AutoCapitalizeTest(TestCase):
 


### PR DESCRIPTION
## Summary

Fixes #496.

In the interactive REPL, `CrashBuffer.is_multiline()` decides whether the
buffer stays in multiline mode by checking whether the raw input text ends
with `;`. A statement with a trailing comment (`select 42; -- foo`) ends with
`-- foo`, so the condition kept the buffer in multiline mode forever and the
session stalled: pressing Enter never submitted the statement. The non
interactive path (`crash -c '...'`) does not go through this buffer, which is
why it worked fine.

## Changes

- `src/crate/crash/repl.py`: `is_multiline` now strips comments with
  `sqlparse.format(text, strip_comments=True)` before looking for the
  terminating semicolon. sqlparse is syntax-aware, so a `;` or `--` inside a
  string literal is untouched. `sqlparse` is already a dependency of crash,
  so no new requirements.
- `tests/test_repl.py`: three new `CrashBufferTest` cases:
  - a statement with a trailing comment is no longer multiline (regression
    test for #496)
  - a statement without a semicolon is still multiline (existing behaviour)
  - a semicolon inside a string literal is still multiline (no over-matching)

## Test evidence

Windows, Python 3.11.9, pytest, sqlparse 0.5.5. Pre-fix full-suite baseline:
66 passed (excluding `test_integration`, which needs a CrateDB server).

Before (upstream code with the new test applied):

```
tests/test_repl.py::CrashBufferTest::test_statement_with_trailing_comment_is_not_multiline FAILED
E       AssertionError: True is not false
========================= 1 failed, 2 passed in 0.79s =========================
```

After:

```
tests/test_repl.py::CrashBufferTest::test_statement_with_trailing_comment_is_not_multiline PASSED
============================== 4 passed in 0.41s ==============================
```

Full suite: `69 passed in 0.60s` — no regressions.
